### PR TITLE
Integrate login UI with Portal API

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+BASE_API_URL = http://localhost:8000/api/v1

--- a/.github/workflows/clean.yml
+++ b/.github/workflows/clean.yml
@@ -20,4 +20,3 @@ jobs:
 
       - name: Delete All Artifacts
         uses: jimschubert/delete-artifacts-action@v1
-

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Increment Android Version
         run: cd android && fastlane bump version:${{ steps.tagName.outputs.version }} && cd ..
 
+      - name: Create ENV File
+        run: echo "BASE_API_URL=${{ secrets.BASE_API_URL }}\nSENTRY_DTN=${{ secrets.SENTRY_DTN }}" > .env
+
       - name: Print Version Changes (Debug)
         run: git --no-pager diff
 
@@ -61,6 +64,7 @@ jobs:
             ./ios/flare.xcodeproj/project.pbxproj
             ./ios/flare/Info.plist
             ./version.txt
+            ./env
 
   # Build script to for iOS apps
   ios:

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -49,9 +49,6 @@ jobs:
       - name: Increment Android Version
         run: cd android && fastlane bump version:${{ steps.tagName.outputs.version }} && cd ..
 
-      - name: Create ENV File
-        run: echo "BASE_API_URL=${{ secrets.BASE_API_URL }}\nAPI_AUTH_TOKEN=${{ secrets.API_AUTH_TOKEN }}\nSENTRY_DTN=${{ secrets.SENTRY_DTN }}" > .env
-
       - name: Print Version Changes (Debug)
         run: git --no-pager diff
 
@@ -88,6 +85,14 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: build-config
+
+      - name: Make envfile
+        uses: SpicyPizza/create-envfile@v1
+        with:
+          file_name: .env
+          envkey_BASE_API_URL: ${{ secrets.BASE_API_URL }}
+          envkey_API_AUTH_TOKEN: ${{ secrets.API_AUTH_TOKEN }}
+          envkey_SENTRY_DTN: ${{ secrets.SENTRY_DTN }}
 
       - name: Install Dependencies
         run: npm install
@@ -140,6 +145,14 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: build-config
+
+      - name: Make envfile
+        uses: SpicyPizza/create-envfile@v1
+        with:
+          file_name: .env
+          envkey_BASE_API_URL: ${{ secrets.BASE_API_URL }}
+          envkey_API_AUTH_TOKEN: ${{ secrets.API_AUTH_TOKEN }}
+          envkey_SENTRY_DTN: ${{ secrets.SENTRY_DTN }}
 
       - name: Install Dependencies
         run: npm install

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -50,7 +50,7 @@ jobs:
         run: cd android && fastlane bump version:${{ steps.tagName.outputs.version }} && cd ..
 
       - name: Create ENV File
-        run: echo "BASE_API_URL=${{ secrets.BASE_API_URL }}\nSENTRY_DTN=${{ secrets.SENTRY_DTN }}" > .env
+        run: echo "BASE_API_URL=${{ secrets.BASE_API_URL }}\nAPI_AUTH_TOKEN=${{ secrets.API_AUTH_TOKEN }}\nSENTRY_DTN=${{ secrets.SENTRY_DTN }}" > .env
 
       - name: Print Version Changes (Debug)
         run: git --no-pager diff

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ experiment data in a custom built web portal.
 - For Android: `npm run android`
 - For iOS: `npm run ios`
 
+## Authentication
+
+To login and thefore start an experiment you will also need to have the [FLARe Portal running](https://github.com/flare-kcl/flare-portal). To avoid this you can also use the Participant ID `local.demo` to load the hardcoded example experiment.
+
 ## 🐍 Testing
 
 We lean heavily on tests in this project to reduce unpredicatble logic and UI bugs. If you would like to contribute

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ experiment data in a custom built web portal.
 - For Android: `npm run android`
 - For iOS: `npm run ios`
 
-## Authentication
+## 🔑 Authentication
 
 To login and thefore start an experiment you will also need to have the [FLARe Portal running](https://github.com/flare-kcl/flare-portal). To avoid this you can also use the Participant ID `local.demo` to load the hardcoded example experiment.
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ experiment data in a custom built web portal.
 
 ## 🔑 Authentication
 
-To login and thefore start an experiment you will also need to have the [FLARe Portal running](https://github.com/flare-kcl/flare-portal). To avoid this you can also use the Participant ID `local.demo` to load the hardcoded example experiment.
+To login and thefore start an experiment you will also need to have the [FLARe Portal](https://github.com/flare-kcl/flare-portal) running on port 8000. To avoid this you can also use the Participant ID `local.demo` to load the hardcoded example experiment.
 
 ## 🐍 Testing
 

--- a/src/controllers/ExperimentViewController.ts
+++ b/src/controllers/ExperimentViewController.ts
@@ -32,11 +32,14 @@ type ExperimentModuleConfig = {
 }
 
 export type Experiment = {
+  id: number
   name: string
   description: string
-  code: string
   contactEmail?: string
   modules: ExperimentModuleConfig[]
+  ratingDelay: number
+  trialLength: number
+  generalisationStimuliEnabled: boolean
   intervalTimeBounds: {
     min: number
     max: number
@@ -196,7 +199,7 @@ export class ExperimentViewController {
   /**
    * Saves the experiment state to aid in recovery
    */
-  private saveExperiment() {
+  saveExperiment() {
     store.dispatch(
       updateExperiment({
         definition: this.experiment,

--- a/src/controllers/FearConditioningModuleViewController.ts
+++ b/src/controllers/FearConditioningModuleViewController.ts
@@ -13,9 +13,6 @@ interface FearConditioningModuleState {
   phase: string
   trialsPerStimulus: number
   reinforcementRate: number
-  ratingDelay: number
-  trialLength: number
-  generalisationStimuliEnabled: boolean
   stimuliImages: any[]
   contextImage: any
   trials?: Trial[]
@@ -81,8 +78,8 @@ export class FearConditioningModuleViewController extends GenericModuleViewContr
     navigateToScreen<any>(FearConditioningTrialScreen.screenID, {
       ...currentTrial,
       trialDelay,
-      ratingDelay: this.moduleState.ratingDelay,
-      trialLength: this.moduleState.trialLength,
+      ratingDelay: experimentVC.experiment.ratingDelay,
+      trialLength: experimentVC.experiment.trialLength,
       contextImage: this.moduleState.contextImage,
       onTrialEnd: (response: FearConditioningTrialResponse) =>
         this.onSubmit(response, experimentVC),

--- a/src/utils/exampleExperiment.ts
+++ b/src/utils/exampleExperiment.ts
@@ -75,6 +75,7 @@ export const exampleCriteriaDefinition = {
 
 // Example data that mocks what portal will return
 export const exampleExperimentData: Experiment = {
+  id: 0,
   name: 'Example Experiment',
   description: `
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc in dui quis odio volutpat pulvinar eu id eros. In ut ipsum ac ipsum varius scelerisque.
@@ -82,8 +83,10 @@ export const exampleExperimentData: Experiment = {
     In elit est, aliquet et aliquet eu, blandit vitae erat. Curabitur finibus dapibus tellus, et scelerisque sem dictum quis.
     Praesent pellentesque rutrum libero, a ultrices ante molestie id. Etiam semper hendrerit feugiat.
   `,
-  code: 'Example',
   contactEmail: 'flare@torchbox.com',
+  ratingDelay: 2000,
+  trialLength: 8000,
+  generalisationStimuliEnabled: true,
   intervalTimeBounds: {
     min: 500,
     max: 1500,
@@ -106,9 +109,6 @@ export const exampleExperimentData: Experiment = {
         phase: 'acquisition',
         trialsPerStimulus: 3,
         reinforcementRate: 3,
-        ratingDelay: 2000,
-        trialLength: 8000,
-        generalisationStimuliEnabled: true,
         contextImage: require('../assets/images/example-context.jpg'),
         stimuliImages: [
           require('../assets/images/small.png'),


### PR DESCRIPTION
This PR links the existing React UI to the authentication endpoint provided on the portal. It also changes the hardcoded 'example experiment' to only work with the unique id `local.demo`.