### PR TITLE
Add keys to module renders in ExperimentContainer

### DIFF
--- a/src/containers/ExperimentContainer.tsx
+++ b/src/containers/ExperimentContainer.tsx
@@ -26,7 +26,7 @@ const ExperimentModuleTypes = {
 type ExperimentModuleConfig = {
   id: string
   moduleType: string
-  definition: Object
+  definition?: Object
 }
 
 export type Experiment = {
@@ -132,6 +132,7 @@ export const ExperimentContainer = () => {
   // Return the current module
   return (
     <ModuleComponent
+      key={`module-screen-${currentModule.moduleId}`}
       module={currentModule.moduleState}
       updateModule={updateModuleState}
       experiment={experiment}

--- a/src/utils/AppStateMonitor.ts
+++ b/src/utils/AppStateMonitor.ts
@@ -52,7 +52,7 @@ export default class AppStateMonitor {
       // Determine timeout mode
       const currentModule = currentModuleSelector(store.getState())
       const applyStrictTimeout =
-        currentModule.moduleType === 'FEAR_CONDITIONING'
+        currentModule?.moduleType === 'FEAR_CONDITIONING'
 
       // Trigger flag if the user had the app suspended for too long.
       if (


### PR DESCRIPTION
This PR fixes a bug where two consecutive FC modules won't work because the module level component isn't unmounted and then remounted. Adding a key forces each module to be unmounted on completion and each new module to be mounted.