### PR TITLE
Improve sentry logging

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,4 +5,7 @@ module.exports = {
     './jest.setup.js',
   ],
   setupFilesAfterEnv: ['@testing-library/jest-native/extend-expect'],
+  transformIgnorePatterns: [
+    'node_modules/(?!(jest-)?react-native|@react-native-picker|@expo(nent)?/.*|expo-*|unimodules-*|@unimodules|@sentry)',
+  ],
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,12 +12,11 @@ import { FlareThemeProvider } from '@utils/theme'
 import { store, peristor } from '@redux/store'
 import { onStateHydrated } from '@redux/persist'
 import { ExperimentContainer } from 'containers/ExperimentContainer'
-import { Stepper } from '@components'
-import { TextInstructionScreen } from '@screens'
 
 // Link with Sentry
 Sentry.init({
   dsn: Config.SENTRY_DTN,
+  enableAutoSessionTracking: true,
 })
 
 // Base container for all screens

--- a/src/screens/FearConditioningTrialScreen.tsx
+++ b/src/screens/FearConditioningTrialScreen.tsx
@@ -2,6 +2,8 @@ import { memo, useState, useEffect, useRef } from 'react'
 import { Audio } from 'expo-av'
 import { EmitterSubscription, ImageSourcePropType } from 'react-native'
 import { useDispatch } from 'react-redux'
+import * as Sentry from '@sentry/react-native'
+
 import { recordEvent } from '@redux/reducers'
 import { Box, TrialImageStack, RatingScale, Interval } from '@components'
 import AudioSensor from '@utils/AudioSensor'
@@ -98,16 +100,16 @@ export const FearConditioningTrialScreen: React.FunctionComponent<FearConditioni
             onSoundStarted()
           }
         })
-      } catch (error) {
-        console.error(error)
+      } catch (err) {
+        Sentry.captureException(err)
       }
     }
 
     const playSound = async () => {
       try {
-        await soundRef.current?.playAsync()
-      } catch (error) {
-        console.error(error)
+        await soundRef.current?.replayAsync()
+      } catch (err) {
+        Sentry.captureException(err)
       }
     }
 


### PR DESCRIPTION
This PR manually sends audio failures to Sentry instead of `console.error`