### PR TITLE
Submit FC trial responses to Portal API

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -285,6 +285,8 @@ PODS:
     - React-Core
   - react-native-date-picker (3.2.5):
     - React-Core
+  - react-native-netinfo (5.9.9):
+    - React-Core
   - react-native-safe-area-context (3.1.8):
     - React-Core
   - react-native-spinkit (1.4.1):
@@ -442,6 +444,7 @@ DEPENDENCIES:
   - React-jsinspector (from `../node_modules/react-native/ReactCommon/jsinspector`)
   - react-native-config (from `../node_modules/react-native-config`)
   - react-native-date-picker (from `../node_modules/react-native-date-picker`)
+  - "react-native-netinfo (from `../node_modules/@react-native-community/netinfo`)"
   - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
   - react-native-spinkit (from `../node_modules/react-native-spinkit`)
   - React-RCTActionSheet (from `../node_modules/react-native/Libraries/ActionSheetIOS`)
@@ -557,6 +560,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-config"
   react-native-date-picker:
     :path: "../node_modules/react-native-date-picker"
+  react-native-netinfo:
+    :path: "../node_modules/@react-native-community/netinfo"
   react-native-safe-area-context:
     :path: "../node_modules/react-native-safe-area-context"
   react-native-spinkit:
@@ -668,6 +673,7 @@ SPEC CHECKSUMS:
   React-jsinspector: 8e68ffbfe23880d3ee9bafa8be2777f60b25cbe2
   react-native-config: f309b9ac19456dea12325699af51e0fa0217ce6a
   react-native-date-picker: 7b03feaea96db983f1de449e9d6d1dea4fa61010
+  react-native-netinfo: 77d133105df525d4a11f10fcaa8d0b8883ea6429
   react-native-safe-area-context: 01158a92c300895d79dee447e980672dc3fb85a6
   react-native-spinkit: da294fd828216ad211fe36a5c14c1e09f09e62db
   React-RCTActionSheet: 53ea72699698b0b47a6421cb1c8b4ab215a774aa

--- a/package-lock.json
+++ b/package-lock.json
@@ -3834,6 +3834,11 @@
       "resolved": "https://registry.npmjs.org/@react-native-community/masked-view/-/masked-view-0.1.10.tgz",
       "integrity": "sha512-rk4sWFsmtOw8oyx8SD3KSvawwaK7gRBSEIy2TAwURyGt+3TizssXP1r8nx3zY+R7v2vYYHXZ+k2/GULAT/bcaQ=="
     },
+    "@react-native-community/netinfo": {
+      "version": "5.9.9",
+      "resolved": "https://registry.npmjs.org/@react-native-community/netinfo/-/netinfo-5.9.9.tgz",
+      "integrity": "sha512-Gp0XV4BgabvzkL4Dp6JAsA2l9LcmgBAq3erCLdvRZmEFz7guCWTogQWVfFtl+IbU0uqfwfo9fm2+mQiwdudLCw=="
+    },
     "@react-native-picker/picker": {
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/@react-native-picker/picker/-/picker-1.9.4.tgz",
@@ -15467,6 +15472,11 @@
         "prop-types": "^15.7.2",
         "react-native-fit-image": "^1.5.5"
       }
+    },
+    "react-native-netinfo": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/react-native-netinfo/-/react-native-netinfo-1.1.0.tgz",
+      "integrity": "sha512-muGzEvfCm9i+MF1qgPF1LsUmRxaTUWQ9i2TTbBoE/DBfsprv4Ds27iYLQvAgX5QzAMJm+iYKCq+3QN/hvPxrsQ=="
     },
     "react-native-picker-select": {
       "version": "8.0.4",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "@react-native-community/async-storage": "^1.12.1",
     "@react-native-community/masked-view": "^0.1.10",
+    "@react-native-community/netinfo": "^5.9.9",
     "@react-native-picker/picker": "^1.9.4",
     "@react-navigation/native": "^5.7.6",
     "@react-navigation/stack": "^5.9.3",
@@ -33,6 +34,7 @@
     "react-native-dotenv": "^2.4.1",
     "react-native-gesture-handler": "^1.7.0",
     "react-native-markdown-display": "^7.0.0-alpha.2",
+    "react-native-netinfo": "^1.1.0",
     "react-native-picker-select": "^8.0.4",
     "react-native-reanimated": "^1.13.1",
     "react-native-safe-area-context": "^3.1.8",

--- a/src/containers/ExperimentContainer.tsx
+++ b/src/containers/ExperimentContainer.tsx
@@ -84,6 +84,14 @@ export const ExperimentContainer = () => {
 
   // If all modules have been completed...
   if (experiment.currentModuleIndex === experiment.definition?.modules.length) {
+    // Mark experiment complete
+    dispatch(
+      updateExperiment({
+        ...experiment,
+        isComplete: true,
+      }),
+    )
+
     // Are all the modules synced?
     if (!experiment.offlineOnly) {
       return (

--- a/src/containers/ExperimentContainer.tsx
+++ b/src/containers/ExperimentContainer.tsx
@@ -85,12 +85,13 @@ export const ExperimentContainer = () => {
   // If all modules have been completed...
   if (experiment.currentModuleIndex === experiment.definition?.modules.length) {
     // Mark experiment complete
-    dispatch(
-      updateExperiment({
-        ...experiment,
-        isComplete: true,
-      }),
-    )
+    if (!experiment.isComplete)
+      dispatch(
+        updateExperiment({
+          ...experiment,
+          isComplete: true,
+        }),
+      )
 
     // Are all the modules synced?
     if (!experiment.offlineOnly) {

--- a/src/containers/ExperimentContainer.tsx
+++ b/src/containers/ExperimentContainer.tsx
@@ -1,5 +1,9 @@
 import { useDispatch, useSelector } from 'react-redux'
-import { experimentSelector, currentModuleSelector } from '@redux/selectors'
+import {
+  experimentSelector,
+  currentModuleSelector,
+  allModulesSelector,
+} from '@redux/selectors'
 import {
   nextModule,
   updateModule,
@@ -10,6 +14,7 @@ import {
   rejectParticipant,
   ExperimentCache,
 } from '@redux/reducers'
+import { syncExperiment } from '@redux/actions'
 import { LoginScreen, RejectionScreen } from '@screens'
 import { TermsContainer } from './TermsContainer'
 import { CriterionContainer } from './CriterionContainer'
@@ -17,6 +22,7 @@ import { FearConditioningContainer } from './FearConditioningContainer'
 import { VolumeCalibrationContainer } from './VolumeCalibrationContainer'
 import { InstructionsContainer } from './InstructionsContainer'
 import { BasicInfoContainer } from './BasicInfoContainer'
+import { SummaryScreen } from '@screens/SummaryScreen'
 
 const ExperimentModuleTypes = {
   BASIC_INFO: BasicInfoContainer,
@@ -68,6 +74,7 @@ export const ExperimentContainer = () => {
   // Get the experiment object and the index of the current module.
   const dispatch = useDispatch()
   const experiment = useSelector(experimentSelector)
+  const experimentModules = useSelector(allModulesSelector)
   const currentModule = useSelector(currentModuleSelector)
 
   // If the user has been 'screened out' then show respective screen
@@ -75,15 +82,28 @@ export const ExperimentContainer = () => {
     return <RejectionScreen onExit={() => terminateExperiment(false)} />
   }
 
+  // If all modules have been completed...
+  if (experiment.currentModuleIndex === experiment.definition?.modules.length) {
+    // Are all the modules synced?
+    if (!experiment.offlineOnly) {
+      return (
+        <SummaryScreen
+          modules={experimentModules}
+          syncExperiment={() => dispatch(syncExperiment)}
+          onExit={() => terminateExperiment(false)}
+        />
+      )
+    } else {
+      terminateExperiment(false)
+    }
+
+    // Render nothing...
+    return null
+  }
+
   // If no experiment saved then return the login
   if (experiment.definition == undefined || currentModule == undefined) {
     return <LoginScreen />
-  }
-
-  // If all modules rendered then go back to login
-  if (experiment.currentModuleIndex === experiment.definition.modules.length) {
-    terminateExperiment(false)
-    return null
   }
 
   // Get the current module data and it's respective component.
@@ -92,7 +112,19 @@ export const ExperimentContainer = () => {
 
   // This function is called when the experiment should transition to next module.
   function onModuleComplete() {
+    // Mark current module as complete
+    dispatch(
+      updateModule({
+        ...currentModule,
+        moduleCompleted: true,
+      }),
+    )
+
+    // Proceed to next module
     dispatch(nextModule())
+
+    // Sync past screen data
+    dispatch(syncExperiment)
   }
 
   // If no matching component then skip it (this avoids issues caused by upgrades)

--- a/src/containers/SummaryContainer.tsx
+++ b/src/containers/SummaryContainer.tsx
@@ -1,0 +1,18 @@
+import { ExperimentModule } from './ExperimentContainer'
+import { SummaryScreen } from '@screens'
+
+type SummaryModuleState = {}
+
+export const SummaryContainer: ExperimentModule<SummaryModuleState> = ({
+  module: mod,
+  onModuleComplete,
+  exitExperiment,
+}) => {
+  return (
+    <SummaryScreen
+      Summary={mod.Summary}
+      onAccept={onModuleComplete}
+      onExit={exitExperiment}
+    />
+  )
+}

--- a/src/redux/actions.ts
+++ b/src/redux/actions.ts
@@ -1,0 +1,101 @@
+import Config from 'react-native-config'
+import { ExperimentCache, ExperimentModule, updateModule } from './reducers'
+import { AppState } from './store'
+import { FearConditioningModuleState } from '@containers/FearConditioningContainer'
+
+export const syncExperiment = async (dispatch, getState: () => AppState) => {
+  // Get Latest State
+  const state = getState()
+  const experiment = state.experiment
+  const modules: ExperimentModule[] = Object.values(state.modules)
+
+  // Finish early if experimennt is offline-only
+  if (experiment.offlineOnly) return
+
+  // Get all modules that have been completed but not synced.
+  for (const mod of modules) {
+    if (mod.moduleCompleted && !mod.moduleSynced) {
+      // Call the specific syncing method and then update the module
+      const onModuleSync = () =>
+        dispatch(
+          updateModule({
+            ...mod,
+            moduleSynced: true,
+          }),
+        )
+
+      switch (mod.moduleType) {
+        case 'FEAR_CONDITIONING':
+          await syncFearConditioningModule(experiment, mod, onModuleSync)
+          break
+
+        default:
+          onModuleSync()
+          console.warn(
+            `Module type ${mod.moduleType} doesn't support data submission!`,
+          )
+      }
+    }
+  }
+}
+
+type ModuleSyncCallback = () => void
+
+const syncFearConditioningModule = async (
+  experiment: ExperimentCache,
+  mod: ExperimentModule<FearConditioningModuleState>,
+  onModuleSync: ModuleSyncCallback,
+) => {
+  // Perform POST request for each recordered trial
+  try {
+    await Promise.all(
+      mod.moduleState.trials.map(async (trial, index) => {
+        // Don't attempt sync if no response
+        if (trial.response === undefined || trial.response?.skipped) return
+
+        // Create the JSON object that the API expects
+        const submissionData = JSON.stringify({
+          trial: index + 1,
+          module: mod.moduleId,
+          participant: experiment.participantID,
+          rating: trial.response?.rating,
+          conditional_stimulus: trial.label,
+          unconditional_stimulus: trial.reinforced,
+          trial_started_at: new Date(trial.response?.startTime).toISOString(),
+          response_recorded_at: new Date(
+            trial.response?.decisionTime,
+          ).toISOString(),
+          volume_level: trial.response?.volume.toFixed(2),
+          headphones: trial.response?.headphonesConnected,
+        })
+
+        try {
+          const response = await fetch(
+            `${Config.BASE_API_URL}/fear-conditioning-data/`,
+            {
+              method: 'POST',
+              headers: {
+                'Accept': 'application/json',
+                'Content-Type': 'application/json',
+                'Authorization': Config.API_AUTH_TOKEN,
+              },
+              body: submissionData,
+            },
+          )
+
+          // If validation error
+          if (response.status === 400) {
+            console.warn('Trial submission could not be processed.')
+          }
+        } catch (err) {
+          console.error(err)
+        }
+      }),
+    )
+
+    // If synced all trials then mark module synec
+    onModuleSync()
+  } catch (err) {
+    console.error('Could not sync all trials', err)
+  }
+}

--- a/src/redux/actions.ts
+++ b/src/redux/actions.ts
@@ -9,7 +9,7 @@ export const syncExperiment = async (dispatch, getState: () => AppState) => {
   const experiment = state.experiment
   const modules: ExperimentModule[] = Object.values(state.modules)
 
-  // Finish early if experimennt is offline-only
+  // Finish early if experiment is offline-only
   if (experiment.offlineOnly) return
 
   // Get all modules that have been completed but not synced.

--- a/src/redux/reducers/experiment.ts
+++ b/src/redux/reducers/experiment.ts
@@ -7,8 +7,9 @@ export type ExperimentCache = {
   definition?: Experiment
   currentModuleIndex?: number
   headphoneType?: HeadphoneType
-  participantRejected?: boolean
+  participantRejected: boolean
   volume?: number
+  isComplete: boolean
 }
 
 export const updateExperiment = createAction<ExperimentCache>(
@@ -25,6 +26,7 @@ const initialState: ExperimentCache = {
   volume: 1,
   currentModuleIndex: 0,
   participantRejected: false,
+  isComplete: true,
 }
 
 export const experimentReducer = createReducer<ExperimentCache>(

--- a/src/redux/reducers/experiment.ts
+++ b/src/redux/reducers/experiment.ts
@@ -1,27 +1,21 @@
 import { createAction, createReducer } from '@reduxjs/toolkit'
 import { Experiment } from '@containers/ExperimentContainer'
-import { HeadphoneType } from '@containers/BasicInfoContainer'
 
 export type ExperimentCache = {
+  participantID?: string
+  offlineOnly?: boolean
   definition?: Experiment
   currentModuleIndex?: number
-  participantRejected: boolean
-  volume: number
   headphoneType?: HeadphoneType
+  participantRejected?: boolean
+  volume?: number
 }
 
-type ExperimentCacheUpdate = {
-  definition: Experiment
-  currentModuleIndex: number
-}
-
-export const updateExperiment = createAction<ExperimentCacheUpdate>(
+export const updateExperiment = createAction<ExperimentCache>(
   'experiment/update',
 )
 
-export const clearExperiment = createAction<ExperimentCacheUpdate>(
-  'experiment/clear',
-)
+export const clearExperiment = createAction<ExperimentCache>('experiment/clear')
 
 export const rejectParticipant = createAction('experiment/reject')
 

--- a/src/redux/reducers/modules.ts
+++ b/src/redux/reducers/modules.ts
@@ -1,13 +1,15 @@
 import { createAction, createReducer } from '@reduxjs/toolkit'
 
-type ModuleCacheUpdate = {
+export type ExperimentModule<StateType = any> = {
   moduleId: string
   moduleType: string
-  moduleState: any
+  moduleState: StateType
+  moduleCompleted?: boolean
+  moduleSynced?: boolean
 }
 
-export const updateModule = createAction<ModuleCacheUpdate>('module/update')
-export const clearAllModules = createAction<ModuleCacheUpdate>(
+export const updateModule = createAction<ExperimentModule>('module/update')
+export const clearAllModules = createAction<ExperimentModule>(
   'module/clear_all',
 )
 

--- a/src/redux/selectors.ts
+++ b/src/redux/selectors.ts
@@ -1,5 +1,5 @@
 import { AppState } from '@redux/store'
-import { EventRecord, ExperimentCache } from '@redux/reducers'
+import { EventRecord, ExperimentCache, ExperimentModule } from '@redux/reducers'
 
 export const experimentSelector = (state: AppState): ExperimentCache =>
   state.experiment
@@ -12,6 +12,14 @@ export const currentModuleSelector = (state: AppState) => {
   const currentModule = state.experiment.definition?.modules[currentIndex]
   return currentModule && moduleSelector(state, currentModule.id)
 }
+
+export const unsyncedModulesSelector = (state: AppState) =>
+  Object.values(state.modules).filter(
+    (mod: ExperimentModule) => mod.moduleCompleted && !mod.moduleSynced,
+  )
+
+export const allModulesSelector = (state: AppState): ExperimentModule[] =>
+  Object.values(state.modules)
 
 export const latestEventSelector = (state: AppState): EventRecord | undefined =>
   state.events[state.events.length - 1]

--- a/src/screens/FearConditioningTrialScreen.tsx
+++ b/src/screens/FearConditioningTrialScreen.tsx
@@ -38,6 +38,7 @@ export type FearConditioningTrialResponse = {
   startTime: number
   decisionTime: number
   volume: number
+  headphonesConnected: boolean
 }
 
 export const FearConditioningTrialScreen: React.FunctionComponent<FearConditioningTrialScreenParams> = memo(
@@ -78,6 +79,7 @@ export const FearConditioningTrialScreen: React.FunctionComponent<FearConditioni
             startTime: startTimeRef.current,
             decisionTime: reactionTimeRef.current,
             volume: await AudioSensor.getCurrentVolume(),
+            headphonesConnected: await AudioSensor.isHeadphonesConnected(),
           })
         }, 500)
       }

--- a/src/screens/LoginScreen.tsx
+++ b/src/screens/LoginScreen.tsx
@@ -197,7 +197,6 @@ async function loginWithID(participantID: string, dispatch) {
         id,
         moduleType: type,
         definition: camelcaseKeys(config),
-        moduleCompleted: false,
       })),
       // TODO: Hardcoded as backend doesn't support yet...
       description: '',
@@ -214,6 +213,8 @@ async function loginWithID(participantID: string, dispatch) {
           moduleId: mod.id,
           moduleType: mod.moduleType,
           moduleState: mod.definition,
+          moduleCompleted: false,
+          moduleSynced: false,
         }),
       )
     })
@@ -221,6 +222,7 @@ async function loginWithID(participantID: string, dispatch) {
     // Save experiment to redux
     dispatch(
       updateExperiment({
+        participantID,
         definition: experiment,
         currentModuleIndex: 0,
       }),
@@ -241,6 +243,8 @@ function demoLogin(dispatch) {
         moduleId: mod.id,
         moduleType: mod.moduleType,
         moduleState: mod.definition,
+        moduleCompleted: false,
+        moduleSynced: false,
       }),
     )
   })
@@ -250,6 +254,7 @@ function demoLogin(dispatch) {
     updateExperiment({
       definition: exampleExperimentData,
       currentModuleIndex: 0,
+      offlineOnly: true,
     }),
   )
 }

--- a/src/screens/SummaryScreen.tsx
+++ b/src/screens/SummaryScreen.tsx
@@ -1,0 +1,99 @@
+import Config from 'react-native-config'
+import { FontAwesome, Entypo } from '@expo/vector-icons'
+import { useNetInfo } from '@react-native-community/netinfo'
+
+import { Box, Text, Button } from '@components'
+import { ExperimentModule } from '@redux/reducers'
+import { palette } from '@utils/theme'
+import { useEffect } from 'react'
+
+type SummaryScreenProps = {
+  modules: ExperimentModule[]
+  syncExperiment: () => void
+  onExit: () => void
+}
+
+export const SummaryScreen: React.FC<SummaryScreenProps> = ({
+  modules,
+  syncExperiment,
+  onExit,
+}) => {
+  const netInfo = useNetInfo()
+  const allModulesSynced =
+    modules.filter((modules) => !modules.moduleCompleted).length === 0
+
+  // Trigger sync when connection is stable
+  useEffect(() => {
+    if (netInfo.isInternetReachable) {
+      syncExperiment()
+    }
+  }, [netInfo.isInternetReachable])
+
+  return (
+    <Box
+      flex={1}
+      alignItems="center"
+      justifyContent="flex-start"
+      pt={24}
+      px={5}
+      backgroundColor="greenPrimary"
+    >
+      <Text variant="heading" mb={9}>
+        {allModulesSynced ? 'Sync Complete!' : 'Syncing Data...'}
+      </Text>
+
+      {/* Show connection status */}
+      {!netInfo.isInternetReachable && !allModulesSynced && (
+        <Box
+          flexDirection="row"
+          justifyContent="space-between"
+          alignItems="center"
+          mb={4}
+          p={4}
+          backgroundColor="lightGrey"
+          borderRadius="m"
+        >
+          <Text variant="heading3" fontWeight="600" color="red">
+            You do not have internet access, Please come back when you have a
+            stable connection.
+          </Text>
+        </Box>
+      )}
+
+      {/* Makeshift table */}
+      <Box width="100%">
+        {modules.map((mod) => (
+          <Box
+            flexDirection="row"
+            justifyContent="space-between"
+            alignItems="center"
+            height={70}
+            mb={4}
+            px={4}
+            backgroundColor="lightGrey"
+            borderRadius="m"
+          >
+            <Text fontWeight="bold" fontSize={16} color="darkGrey">
+              ({mod.moduleId}) {mod.moduleType}
+            </Text>
+            {mod.moduleSynced ? (
+              <FontAwesome name="check" size={24} color={palette.purple} />
+            ) : (
+              <Entypo name="squared-cross" size={24} color={palette.red} />
+            )}
+          </Box>
+        ))}
+      </Box>
+
+      {allModulesSynced && (
+        <Box flex={1} justifyContent="flex-end" pb={14}>
+          <Button
+            variant="primary"
+            label="Complete Experiment"
+            onPress={onExit}
+          />
+        </Box>
+      )}
+    </Box>
+  )
+}

--- a/src/utils/AppStateMonitor.ts
+++ b/src/utils/AppStateMonitor.ts
@@ -8,7 +8,7 @@ import {
   recordEvent,
   rejectParticipant,
 } from '@redux/reducers'
-import { currentModuleSelector } from '@redux/selectors'
+import { currentModuleSelector, experimentSelector } from '@redux/selectors'
 
 const SUSPENDED_TIMEOUT = 60000
 const STRICT_SUSPENED_TIMEOUT = 30000
@@ -50,14 +50,16 @@ export default class AppStateMonitor {
       )
 
       // Determine timeout mode
+      const experiment = experimentSelector(store.getState())
       const currentModule = currentModuleSelector(store.getState())
       const applyStrictTimeout =
         currentModule?.moduleType === 'FEAR_CONDITIONING'
 
       // Trigger flag if the user had the app suspended for too long.
       if (
-        suspendedTime > SUSPENDED_TIMEOUT ||
-        (applyStrictTimeout && suspendedTime > STRICT_SUSPENED_TIMEOUT)
+        !experiment.isComplete &&
+        (suspendedTime > SUSPENDED_TIMEOUT ||
+          (applyStrictTimeout && suspendedTime > STRICT_SUSPENED_TIMEOUT))
       ) {
         store.dispatch(rejectParticipant())
       }

--- a/src/utils/exampleExperiment.ts
+++ b/src/utils/exampleExperiment.ts
@@ -132,9 +132,9 @@ export const exampleExperimentData: Experiment = {
         trialsPerStimulus: 3,
         reinforcementRate: 3,
         contextImage: require('../assets/images/example-context.jpg'),
-        stimuliImages: [
-          require('../assets/images/small.png'),
-          require('../assets/images/large.png'),
+        stimuli: [
+          { label: 'CSA', image: require('../assets/images/small.png') },
+          { label: 'CSB', image: require('../assets/images/large.png') },
         ],
       },
     },


### PR DESCRIPTION
This PR adds support for tracking if modules are completed and if they have been synced with the Portal API. The only supported module so far is Fear Conditioning. This PR also adds a summary screen to the end of an experiment that stops the user terminating the experiment without uploading data.