### PR TITLE
Send calibrated volume to portal for each trial

### DIFF
--- a/src/containers/FearConditioningContainer.tsx
+++ b/src/containers/FearConditioningContainer.tsx
@@ -166,7 +166,7 @@ function generateTrials(
   // Create equal amounts of trials
   let positiveStimuliTrials: Trial[] = []
   let negativeStimuliTrials: Trial[] = []
-  for (var i = 0; i <= trialsPerStimulus; i++) {
+  for (var i = 0; i < trialsPerStimulus; i++) {
     // Generate positive stimulus trial
     positiveStimuliTrials.push({
       label: positiveStimuli.label,

--- a/src/redux/actions.ts
+++ b/src/redux/actions.ts
@@ -66,6 +66,7 @@ const syncFearConditioningModule = async (
             trial.response?.decisionTime,
           ).toISOString(),
           volume_level: trial.response?.volume.toFixed(2),
+          calibrated_volume_level: experiment.volume.toFixed(2),
           headphones: trial.response?.headphonesConnected,
         })
 


### PR DESCRIPTION
This PR allows the app to send the calibrated volume level to the portal with each trial response. Currently this value will always be 1 because volume calibration modules don't exist in the portal. We also fix an issue where too many trials are generated.... oops.

This PR is dependent on: https://github.com/flare-kcl/flare-portal/pull/53