### PR TITLE
Make RatingScale length customizable

### DIFF
--- a/src/components/RatingScale.tsx
+++ b/src/components/RatingScale.tsx
@@ -16,6 +16,7 @@ type RatingScaleProps = {
   lockFirstRating?: boolean
   onChange?: (value: number) => void
   disabled?: boolean
+  ratingOptions?: number[]
 }
 
 export const RatingScale: React.FunctionComponent<RatingScaleProps> = ({
@@ -25,15 +26,15 @@ export const RatingScale: React.FunctionComponent<RatingScaleProps> = ({
   onChange,
   disabled,
   lockFirstRating = true,
+  ratingOptions = [1, 2, 3, 4, 5, 6, 7, 8, 9],
 }) => {
   // Keep track of selected value
-  const ratingOptions = [1, 2, 3, 4, 5, 6, 7, 8, 9]
   const [locked, setLocked] = useState(false)
   const [currentButton, setCurrentButton] = useState<number>()
 
   // Calculate size of buttons
   const screenWidth = Dimensions.get('screen').width
-  const boxSize = 0.1 * screenWidth
+  const boxSize = (1 / (ratingOptions.length + 1)) * screenWidth
 
   // Only lock if specified via props
   const setRatingLocked = (locked: boolean) => {
@@ -70,8 +71,10 @@ export const RatingScale: React.FunctionComponent<RatingScaleProps> = ({
     const { absoluteX } = event.nativeEvent
     // See what segment along scale the finger is scrolling past
     let value = Math.round((absoluteX / screenWidth) * ratingOptions.length)
-    // Apply 1-9 bounds to value
-    value = value < 1 ? 1 : value > 9 ? 9 : value
+    // Apply 1-n bounds to value
+    const minValue = ratingOptions[0]
+    const maxValue = ratingOptions[ratingOptions.length - 1]
+    value = value < minValue ? minValue : value > maxValue ? maxValue : value
     if (!locked) {
       setSelectionOption(value, true)
     }

--- a/src/screens/DeviceInfoScreen.tsx
+++ b/src/screens/DeviceInfoScreen.tsx
@@ -45,7 +45,7 @@ export const DeviceInfoScreen: React.FunctionComponent<DeviceInfoScreenProps> = 
       manufacturer: Device.manufacturer,
       version: Device.osVersion,
       operatingSystem: Device.osName,
-      gender: genderValue,
+      gender: genderValue ?? genders[0],
       dob: dobValue,
     })
   }, [dobValue, genderValue])

--- a/src/screens/VolumeCalibrationScreen.tsx
+++ b/src/screens/VolumeCalibrationScreen.tsx
@@ -144,13 +144,13 @@ export const VolumeCalibrationScreen: React.FunctionComponent<VolumeCalibrationS
     }
 
     // If sound is painful then decrement one step and repeat calibration
-    else if (volumeRating == 9) {
+    else if (volumeRating == 10) {
       decrementVolume()
       setStage(VolumeCalibrationStages.Error)
     }
 
     // User finds volume painful, let's verify they want to continue
-    else if (volumeRating === 8) {
+    else if (volumeRating === 9) {
       Alert.alert(
         'Are you sure',
         'You may hear sounds at this volume multiple times during the experiment. Do you think you can tolerate this volume?',
@@ -256,6 +256,7 @@ export const VolumeCalibrationScreen: React.FunctionComponent<VolumeCalibrationS
               anchorLabelRight="Painful"
               lockFirstRating={false}
               onChange={(rating) => setVolumeRating(rating)}
+              ratingOptions={[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]}
             />
             <Box px={5}>
               <Button variant="primary" label="Next" onPress={validateRating} />


### PR DESCRIPTION
This PR allows you to set custom `ratingOptions` for the rating scale. Using this change we have expanded the volume calibration rating from 9 to 10 options.

Codebase Ticket: https://projects.torchbox.com/projects/flare-rebuild/tickets/42#update-65645367

Screenshot:
<img width="390" alt="Screenshot 2020-12-15 at 10 24 20" src="https://user-images.githubusercontent.com/13197111/102202831-b322a580-3ebf-11eb-8294-1e508d026b13.png">
