### PR TITLE
Add missing intergration fields

### DIFF
--- a/src/containers/FearConditioningContainer.tsx
+++ b/src/containers/FearConditioningContainer.tsx
@@ -123,7 +123,7 @@ export const FearConditioningContainer: ExperimentModule<FearConditioningModuleS
   // Calculate a random trial interval length
   const intervalBounds = experiment.definition.intervalTimeBounds
   const trialDelay =
-    Math.floor(Math.random() * intervalBounds.max) + intervalBounds.min
+    (Math.floor(Math.random() * intervalBounds.max) + intervalBounds.min) * 1000
 
   // Render the current trial
   const currentTrial = mod.trials[mod.currentTrialIndex]

--- a/src/screens/LoginScreen.tsx
+++ b/src/screens/LoginScreen.tsx
@@ -205,6 +205,13 @@ async function loginWithID(participantID: string, dispatch) {
     const experiment: Experiment = {
       id: experimentApiData.experiment.id,
       name: experimentApiData.experiment.name,
+      description: experimentApiData.experiment.description,
+      ratingScaleAnchorLabelLeft:
+        experimentApiData.experiment.rating_scale_anchor_label_left,
+      ratingScaleAnchorLabelRight:
+        experimentApiData.experiment.rating_scale_anchor_label_right,
+      ratingScaleAnchorLabelCenter:
+        experimentApiData.experiment.rating_scale_anchor_label_center,
       trialLength: experimentApiData.experiment.trial_length * 1000,
       ratingDelay: experimentApiData.experiment.rating_delay * 1000,
       modules: experimentApiData.modules.map(({ id, type, config }) => ({
@@ -212,11 +219,9 @@ async function loginWithID(participantID: string, dispatch) {
         moduleType: type,
         definition: camelcaseKeys(config),
       })),
-      // TODO: Hardcoded as backend doesn't support yet...
-      description: '',
       intervalTimeBounds: {
-        min: 500,
-        max: 1500,
+        min: experimentApiData.experiment.iti_min_delay,
+        max: experimentApiData.experiment.iti_max_delay,
       },
     }
 
@@ -239,6 +244,7 @@ async function loginWithID(participantID: string, dispatch) {
         participantID,
         definition: experiment,
         currentModuleIndex: 0,
+        isComplete: false,
       }),
     )
   } catch (err) {
@@ -269,6 +275,7 @@ function demoLogin(dispatch) {
       definition: exampleExperimentData,
       currentModuleIndex: 0,
       offlineOnly: true,
+      isComplete: false,
     }),
   )
 }

--- a/src/utils/exampleExperiment.ts
+++ b/src/utils/exampleExperiment.ts
@@ -90,8 +90,8 @@ export const exampleExperimentData: Experiment = {
   ratingScaleAnchorLabelCenter: 'Uncertain',
   ratingScaleAnchorLabelRight: 'Certain scream',
   intervalTimeBounds: {
-    min: 500,
-    max: 1500,
+    min: 1,
+    max: 3,
   },
   modules: [
     {


### PR DESCRIPTION
This PR add's the missing experiment fields from the configuration API. This includes the ITI bounds and description (although it's currently not used).

Dependent on: https://github.com/flare-kcl/flare-portal/pull/54