### PR TITLE
Add autoclose link to example experiment data

### DIFF
--- a/src/screens/ExternalLinkScreen.tsx
+++ b/src/screens/ExternalLinkScreen.tsx
@@ -1,3 +1,6 @@
+import { useRef } from 'react'
+import { TouchableOpacity } from 'react-native'
+import { MaterialIcons } from '@expo/vector-icons'
 import { WebView, WebViewNavigation } from 'react-native-webview'
 
 import { Box, Text, Button, SafeAreaView } from '@components'
@@ -17,6 +20,7 @@ export const ExternalLinkScreen: React.FunctionComponent<ExternalLinkScreenProps
   closeDetectionMatch,
 }) => {
   const Alert = useAlert()
+  const webView = useRef<any>()
   const onNavigationStateChange = (navigation: WebViewNavigation) => {
     if (closeDetectionMatch && navigation.url.includes(closeDetectionMatch)) {
       onNext()
@@ -40,6 +44,12 @@ export const ExternalLinkScreen: React.FunctionComponent<ExternalLinkScreenProps
     )
   }
 
+  // Force the webview to reset to original origin (This is the recommended way...)
+  const resetWebView = () => {
+    const redirectTo = 'window.location = "' + link + '"'
+    webView.current.injectJavaScript(redirectTo)
+  }
+
   return (
     <SafeAreaView flex={1} backgroundColor="purple">
       <Box
@@ -48,7 +58,11 @@ export const ExternalLinkScreen: React.FunctionComponent<ExternalLinkScreenProps
         paddingVertical={4}
         alignItems="center"
       >
-        <Box width="25%" />
+        <Box width="25%" pl={5}>
+          <TouchableOpacity onPress={resetWebView}>
+            <MaterialIcons name="loop" size={24} color="white" />
+          </TouchableOpacity>
+        </Box>
         <Box width="50%" alignItems="center">
           <Text color="white" fontSize={16} fontWeight="600">
             {title}
@@ -68,7 +82,9 @@ export const ExternalLinkScreen: React.FunctionComponent<ExternalLinkScreenProps
         />
       </Box>
       <WebView
+        ref={webView}
         source={{ uri: link }}
+        allowsBackForwardNavigationGestures
         onNavigationStateChange={onNavigationStateChange}
       />
     </SafeAreaView>

--- a/src/utils/exampleExperiment.ts
+++ b/src/utils/exampleExperiment.ts
@@ -145,6 +145,8 @@ export const exampleExperimentData: Experiment = {
         title: 'FLARe Questionnaire',
         description: `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc in dui quis odio volutpat pulvinar eu id eros. In ut ipsum ac ipsum varius scelerisque. Pellentesque nec neque vel odio tempor aliquam. Aliquam rutrum vestibulum ligula, eget viverra mauris porta id.`,
         link: 'https://kclbs.eu.qualtrics.com/jfe/form/SV_802kLj0WlUSVByd',
+        closeDetectionMatch:
+          'http://flare-portal.staging.torchbox.com/redirect',
       },
     },
   ],


### PR DESCRIPTION
This PR tells the external link module in the example experiment to watch for any url changes, If it detects the url change matches the `closeDetectionMatch` then it calls the `onModuleComplete` function.