### PR TITLE
Fix random ITI duration snippet

### DIFF
--- a/src/containers/FearConditioningContainer.tsx
+++ b/src/containers/FearConditioningContainer.tsx
@@ -123,7 +123,10 @@ export const FearConditioningContainer: ExperimentModule<FearConditioningModuleS
   // Calculate a random trial interval length
   const intervalBounds = experiment.definition.intervalTimeBounds
   const trialDelay =
-    (Math.floor(Math.random() * intervalBounds.max) + intervalBounds.min) * 1000
+    Math.floor(
+      Math.random() * (intervalBounds.max - intervalBounds.min + 1) +
+        intervalBounds.min,
+    ) * 1000
 
   // Render the current trial
   const currentTrial = mod.trials[mod.currentTrialIndex]


### PR DESCRIPTION
This PR fixes the code for generating a random ITI duration. The current code expected a range starting at 1, which is incorrect.