### PR TITLE
Integrate the T&C’s module

### DIFF
--- a/src/containers/TermsContainer.tsx
+++ b/src/containers/TermsContainer.tsx
@@ -1,7 +1,7 @@
 import { ExperimentModule } from './ExperimentContainer'
 import { TermsScreen } from '@screens'
 
-type TermsModuleState = {
+export type TermsModuleState = {
   terms: string
 }
 

--- a/src/redux/actions.ts
+++ b/src/redux/actions.ts
@@ -4,6 +4,7 @@ import { FearConditioningModuleState } from '@containers/FearConditioningContain
 import { PortalAPI } from '@utils/PortalAPI'
 import { BasicInfoContainerState } from '@containers/BasicInfoContainer'
 import { CriteriaModuleState } from '@containers/CriterionContainer'
+import { TermsModuleState } from '@containers/TermsContainer'
 
 export const syncExperiment = async (dispatch, getState: () => AppState) => {
   // Get Latest State
@@ -37,6 +38,10 @@ export const syncExperiment = async (dispatch, getState: () => AppState) => {
 
         case 'CRITERION':
           await syncCriterionModule(experiment, mod, onModuleSync)
+          break
+
+        case 'TERMS':
+          await syncTermsModule(experiment, mod, onModuleSync)
           break
 
         default:
@@ -151,6 +156,19 @@ const syncBasicInfoModule = async (
     })
 
     // Mark module as synced
+    onModuleSync()
+  } catch (err) {
+    console.error(err)
+  }
+}
+
+const syncTermsModule = async (
+  experiment: ExperimentCache,
+  mod: ExperimentModule<TermsModuleState>,
+  onModuleSync: ModuleSyncCallback,
+) => {
+  try {
+    await PortalAPI.submitTermsAgree(experiment.participantID)
     onModuleSync()
   } catch (err) {
     console.error(err)

--- a/src/utils/PortalAPI.ts
+++ b/src/utils/PortalAPI.ts
@@ -59,6 +59,19 @@ export class PortalAPI {
       console.warn('Criterion answer could not be processed.')
     }
   }
+
+  static async submitTermsAgree(participantID: string) {
+    const jsonData = JSON.stringify({ participant: participantID })
+    const response = await PortalAPI.executeAPIRequest(
+      'terms-and-conditions',
+      jsonData,
+    )
+
+    // If validation error
+    if (response.status === 400) {
+      console.warn("Could not agree to T&C's")
+    }
+  }
 }
 
 type PortalTrialRatingSubmission = {


### PR DESCRIPTION
This PR adds support for using the T&C's as defined in the portal.

## Technical Changes
- On login check if config object has T&C's. If so then append a Terms module to top of stack.
- Fire at Terms API endpoint like we are syncing any other module

Codebase Ticket: https://projects.torchbox.com/projects/flare-rebuild/tickets/69