### PR TITLE
Submit blank string instead of undefined for gender param

### DIFF
--- a/src/redux/actions.ts
+++ b/src/redux/actions.ts
@@ -140,7 +140,7 @@ const syncBasicInfoModule = async (
       participant: experiment.participantID,
       module: mod.moduleId,
       date_of_birth: mod.moduleState.dob,
-      gender: mod.moduleState.gender,
+      gender: mod.moduleState.gender ?? '',
       headphone_type: mod.moduleState.headphoneType,
       device_make: mod.moduleState.manufacturer,
       device_model: mod.moduleState.model,


### PR DESCRIPTION
This PR fixes the validation error caused by submitting an undefined value as the gender param when submitting a BasicInfoModule's data.