### PR TITLE
Refine trial generation + Add tests

### DIFF
--- a/src/containers/ExperimentContainer.tsx
+++ b/src/containers/ExperimentContainer.tsx
@@ -75,7 +75,7 @@ export type Experiment = {
       }
     | NodeModule
   contextStimuli: { [key: string]: ImageSourcePropType }
-  conditionalStimuli: VisualStimuli[]
+  conditionalStimuli: { [key: string]: VisualStimuli }
   generalisationStimuli: VisualStimuli[]
 }
 

--- a/src/containers/__tests__/TrialsGeneration.test.ts
+++ b/src/containers/__tests__/TrialsGeneration.test.ts
@@ -1,0 +1,48 @@
+import { generateTrials } from '@containers/FearConditioningContainer'
+import { exampleExperimentData } from '@utils/exampleExperiment'
+
+test('Trials generated correctly', () => {
+  const testTrials = (trialsPerStimulus, reinforcementRate) => {
+    // Generate a set of trials, CSA is always CS+
+    const trials = generateTrials(
+      trialsPerStimulus,
+      reinforcementRate,
+      exampleExperimentData.conditionalStimuli['cs+'],
+      exampleExperimentData.conditionalStimuli['cs-'],
+      exampleExperimentData.generalisationStimuli,
+    )
+
+    // Check generated expected number of trials
+    const computedLength =
+      trialsPerStimulus *
+      (2 + exampleExperimentData.generalisationStimuli.length)
+    expect(trials.length).toEqual(computedLength)
+
+    // Check stimuli are split evenly
+    const csaTrials = trials.filter((trial) => trial.label == 'csa')
+    const csbTrials = trials.filter((trial) => trial.label == 'csb')
+    const gsaTrials = trials.filter((trial) => trial.label.startsWith('gsa'))
+    const gsbTrials = trials.filter((trial) => trial.label.startsWith('gsb'))
+    const gscTrials = trials.filter((trial) => trial.label.startsWith('gsc'))
+    const gsdTrials = trials.filter((trial) => trial.label.startsWith('gsd'))
+    expect(csaTrials.length).toEqual(trialsPerStimulus)
+    expect(csbTrials.length).toEqual(trialsPerStimulus)
+    expect(gsaTrials.length).toEqual(trialsPerStimulus)
+    expect(gsbTrials.length).toEqual(trialsPerStimulus)
+    expect(gscTrials.length).toEqual(trialsPerStimulus)
+    expect(gsdTrials.length).toEqual(trialsPerStimulus)
+
+    // Check correct amount of trials reinforced
+    const reinforcedTrials = csaTrials.filter((trial) => trial.reinforced)
+    const invalidTrials = csbTrials.filter((trial) => trial.reinforced)
+    expect(reinforcedTrials.length).toEqual(reinforcementRate)
+    expect(invalidTrials.length).toEqual(0)
+  }
+
+  // Test trials generation for a range of values
+  testTrials(10, 4)
+  testTrials(1, 0)
+  testTrials(1, 1)
+  testTrials(2, 1)
+  testTrials(3, 3)
+})

--- a/src/screens/LoginScreen.tsx
+++ b/src/screens/LoginScreen.tsx
@@ -6,6 +6,7 @@ import Config from 'react-native-config'
 import camelcaseKeys from 'camelcase-keys'
 import Constants from 'expo-constants'
 import * as Sentry from '@sentry/react-native'
+import { shuffle } from 'lodash'
 
 import { Experiment } from '@containers/ExperimentContainer'
 import { Box, Text, Button, Image, TextField, SafeAreaView } from '@components'
@@ -261,6 +262,12 @@ async function loginWithID(participantID: string, dispatch) {
       }
     }
 
+    // Shuffle CS and assign to CS+/CS-
+    const conditionalStimuli = await shuffle([
+      await cacheVisualStimuli('csa', experimentApiData.experiment.csa),
+      await cacheVisualStimuli('csb', experimentApiData.experiment.csb),
+    ])
+
     // Covert API data to experiment type
     const experiment: Experiment = {
       id: experimentApiData.experiment.id,
@@ -287,10 +294,10 @@ async function loginWithID(participantID: string, dispatch) {
       unconditionalStimulus: await cacheRemoteAsset(
         experimentApiData.experiment.us,
       ),
-      conditionalStimuli: [
-        await cacheVisualStimuli('csa', experimentApiData.experiment.csa),
-        await cacheVisualStimuli('csb', experimentApiData.experiment.csb),
-      ].filter((cs) => cs != null),
+      conditionalStimuli: {
+        'cs+': conditionalStimuli[0],
+        'cs-': conditionalStimuli[1],
+      },
       generalisationStimuli: [
         await cacheVisualStimuli('gsa', experimentApiData.experiment.gsa),
         await cacheVisualStimuli('gsb', experimentApiData.experiment.gsb),

--- a/src/utils/exampleExperiment.ts
+++ b/src/utils/exampleExperiment.ts
@@ -98,10 +98,10 @@ export const exampleExperimentData: Experiment = {
   contextStimuli: {
     A: require('../assets/images/example-context.png'),
   },
-  conditionalStimuli: [
-    { label: 'csa', image: require('../assets/images/CSA.png') },
-    { label: 'csb', image: require('../assets/images/CSB.png') },
-  ],
+  conditionalStimuli: {
+    'cs+': { label: 'csa', image: require('../assets/images/CSA.png') },
+    'cs-': { label: 'csb', image: require('../assets/images/CSB.png') },
+  },
   generalisationStimuli: [
     { label: 'gsa', image: require('../assets/images/GSA.png') },
     { label: 'gsb', image: require('../assets/images/GSB.png') },


### PR DESCRIPTION
This PR alters the trial generation logic, The following changes have been made:

- CS+/CS- is decided randomly upon login
- Trials Per Stimulus now effects the GS
- Added tests
- Fix issue with for loops