### PR TITLE
Simplify WebModule `getFormattedURL` method

### DIFF
--- a/src/containers/ExternalLinkContainer.tsx
+++ b/src/containers/ExternalLinkContainer.tsx
@@ -18,11 +18,7 @@ export const ExternalLinkContainer: ExperimentModule<ExternalLinkModuleState> = 
 }) => {
   const getFormattedURL = () => {
     if (mod.appendParticipantId) {
-      // Parse the URL
-      const url = new URL(mod.url)
-      // Add search param
-      url.searchParams.set('participantID', experiment.participantID)
-      return url.toString()
+      return mod.url + experiment.participantID
     }
 
     return mod.url


### PR DESCRIPTION
Simplify Web Module getFormattedURL to simply append ID instead of embedding as param.