### PR TITLE
#93: Add Break module

### DIFF
--- a/src/containers/BreakEndContainer.tsx
+++ b/src/containers/BreakEndContainer.tsx
@@ -30,7 +30,8 @@ export const BreakEndContainer: ExperimentModule<BreakEndModuleState> = ({
   const [extendedTimeRemaining, setExtendedTimeRemaining] = useState<string>()
 
   // Convert string to date
-  const breakEndDate = experiment.breakEndDate && Date.parse(experiment.breakEndDate)
+  const breakEndDate =
+    experiment.breakEndDate && Date.parse(experiment.breakEndDate)
 
   const enableTimeout = () => {
     // Enable timeout again
@@ -59,10 +60,7 @@ export const BreakEndContainer: ExperimentModule<BreakEndModuleState> = ({
     }
 
     // Calculate how long left
-    const secondsRemaining = differenceInSeconds(
-      breakEndDate,
-      new Date(),
-    )
+    const secondsRemaining = differenceInSeconds(breakEndDate, new Date())
 
     const duration = intervalToDuration({
       start: new Date(),
@@ -72,7 +70,11 @@ export const BreakEndContainer: ExperimentModule<BreakEndModuleState> = ({
     // If over 24 hours then use something nicer than countown clock
     if (secondsRemaining >= 86400) {
       setTimeRemaining(null)
-      setExtendedTimeRemaining(formatDuration(duration))
+      setExtendedTimeRemaining(
+        formatDuration(duration, {
+          format: ['years', 'months', 'weeks', 'days', 'hours', 'minutes'],
+        }),
+      )
     } else {
       setExtendedTimeRemaining(null)
       setTimeRemaining(
@@ -107,16 +109,10 @@ export const BreakEndContainer: ExperimentModule<BreakEndModuleState> = ({
     <BreakEndScreen
       heading={mod.endTitle}
       description={mod.endBody}
-      timerText={
-        canContinue
-          ? 'Break Over'
-          : timeRemaining
-      }
-      eta={format(breakEndDate, "dd/MM/yyyy - HH:mm:ss")}
+      timerText={canContinue ? 'Break Over' : timeRemaining}
+      eta={format(breakEndDate, 'dd/MM/yyyy - HH:mm:ss')}
       extendedTimerText={extendedTimeRemaining}
-      actionLabel={
-        canContinue && "Select 'next' to continue with experiment."
-      }
+      actionLabel={canContinue && "Select 'next' to continue with experiment."}
       buttonDisabled={!canContinue}
       onNext={() => enableTimeout()}
     />

--- a/src/containers/BreakEndContainer.tsx
+++ b/src/containers/BreakEndContainer.tsx
@@ -25,7 +25,7 @@ export const BreakEndContainer: ExperimentModule<BreakEndModuleState> = ({
   updateExperiment,
 }) => {
   const timerRef = useRef<any>()
-  const [canContinue, setcanContinue] = useState(false)
+  const [canContinue, setCanContinue] = useState(false)
   const [timeRemaining, setTimeRemaining] = useState<string>()
   const [extendedTimeRemaining, setExtendedTimeRemaining] = useState<string>()
 
@@ -45,7 +45,7 @@ export const BreakEndContainer: ExperimentModule<BreakEndModuleState> = ({
 
   const onTimerTick = () => {
     const cancelCountdown = () => {
-      setcanContinue(true)
+      setCanContinue(true)
       clearInterval(timerRef.current)
     }
 
@@ -87,12 +87,12 @@ export const BreakEndContainer: ExperimentModule<BreakEndModuleState> = ({
 
   // Start countdown timer
   useEffect(() => {
-    // If we break has passed quit early...
+    // If the break has expired then quit early...
     if (
       breakEndDate == undefined ||
       isPast(Date.parse(experiment.breakEndDate))
     ) {
-      setcanContinue(true)
+      setCanContinue(true)
       return
     }
 

--- a/src/containers/BreakEndContainer.tsx
+++ b/src/containers/BreakEndContainer.tsx
@@ -1,0 +1,124 @@
+import { useRef, useState } from 'react'
+import { ExperimentModule } from './ExperimentContainer'
+import { TextInstructionScreen } from '@screens'
+import { useEffect } from 'react'
+import {
+  isPast,
+  addSeconds,
+  formatDuration,
+  intervalToDuration,
+  differenceInSeconds,
+} from 'date-fns'
+import { BreakEndScreen } from '@screens/BreakEndScreen'
+import { format } from 'date-fns/esm'
+
+export type BreakEndModuleState = {
+  endTitle: number
+  endBody: number
+  duration: number
+}
+
+export const BreakEndContainer: ExperimentModule<BreakEndModuleState> = ({
+  module: mod,
+  experiment,
+  onModuleComplete,
+  updateExperiment,
+}) => {
+  const timerRef = useRef<any>()
+  const [canContinue, setcanContinue] = useState(false)
+  const [timeRemaining, setTimeRemaining] = useState<string>()
+  const [extendedTimeRemaining, setExtendedTimeRemaining] = useState<string>()
+
+  // Convert string to date
+  const breakEndDate = experiment.breakEndDate && Date.parse(experiment.breakEndDate)
+
+  const enableTimeout = () => {
+    // Enable timeout again
+    updateExperiment({
+      breakEndDate: undefined,
+    })
+
+    // Continue to next module
+    onModuleComplete()
+  }
+
+  const onTimerTick = () => {
+    const cancelCountdown = () => {
+      setcanContinue(true)
+      clearInterval(timerRef.current)
+    }
+
+    // Cancel if end time becomes invalid
+    if (breakEndDate === undefined) {
+      cancelCountdown()
+    }
+
+    // Cancel timer if we have met end
+    if (isPast(breakEndDate)) {
+      cancelCountdown()
+    }
+
+    // Calculate how long left
+    const secondsRemaining = differenceInSeconds(
+      breakEndDate,
+      new Date(),
+    )
+
+    const duration = intervalToDuration({
+      start: new Date(),
+      end: breakEndDate,
+    })
+
+    // If over 24 hours then use something nicer than countown clock
+    if (secondsRemaining >= 86400) {
+      setTimeRemaining(null)
+      setExtendedTimeRemaining(formatDuration(duration))
+    } else {
+      setExtendedTimeRemaining(null)
+      setTimeRemaining(
+        `${String(duration.hours).padStart(2, '0')}:${String(
+          duration.minutes,
+        ).padStart(2, '0')}:${String(duration.seconds).padStart(2, '0')}`,
+      )
+    }
+  }
+
+  // Start countdown timer
+  useEffect(() => {
+    // If we break has passed quit early...
+    if (
+      breakEndDate == undefined ||
+      isPast(Date.parse(experiment.breakEndDate))
+    ) {
+      setcanContinue(true)
+      return
+    }
+
+    // Start a countdown timer
+    timerRef.current = setInterval(onTimerTick, 500)
+
+    // Delete timer on app exit
+    return () => {
+      clearInterval(timerRef.current)
+    }
+  }, [])
+
+  return (
+    <BreakEndScreen
+      heading={mod.endTitle}
+      description={mod.endBody}
+      timerText={
+        canContinue
+          ? 'Break Over'
+          : timeRemaining
+      }
+      eta={format(breakEndDate, "dd/MM/yyyy - HH:mm:ss")}
+      extendedTimerText={extendedTimeRemaining}
+      actionLabel={
+        canContinue && "Select 'next' to continue with experiment."
+      }
+      buttonDisabled={!canContinue}
+      onNext={() => enableTimeout()}
+    />
+  )
+}

--- a/src/containers/BreakStartContainer.tsx
+++ b/src/containers/BreakStartContainer.tsx
@@ -1,0 +1,33 @@
+import { ExperimentModule } from './ExperimentContainer'
+import { TermsScreen, TextInstructionScreen } from '@screens'
+import { useEffect } from 'react'
+import { addSeconds } from 'date-fns'
+
+export type BreakStartModuleState = {
+  startTitle: number
+  startBody: number
+  duration: number
+}
+
+export const BreakStartContainer: ExperimentModule<BreakStartModuleState> = ({
+  module: mod,
+  onModuleComplete,
+  updateExperiment,
+}) => {
+  // Disable timeout for this experiment until n seconds in future.
+  useEffect(() => {
+    updateExperiment({
+      breakEndDate: addSeconds(new Date(), mod.duration),
+    })
+  }, [])
+
+  return (
+    <TextInstructionScreen
+      heading={mod.startTitle}
+      description={mod.startBody}
+      textAlign='left'
+      actionLabel="Select 'next' to start break tasks"
+      onNext={() => onModuleComplete()}
+    />
+  )
+}

--- a/src/containers/BreakStartContainer.tsx
+++ b/src/containers/BreakStartContainer.tsx
@@ -25,7 +25,7 @@ export const BreakStartContainer: ExperimentModule<BreakStartModuleState> = ({
     <TextInstructionScreen
       heading={mod.startTitle}
       description={mod.startBody}
-      textAlign='left'
+      textAlign="left"
       actionLabel="Select 'next' to start break tasks"
       onNext={() => onModuleComplete()}
     />

--- a/src/containers/ExperimentContainer.tsx
+++ b/src/containers/ExperimentContainer.tsx
@@ -33,6 +33,8 @@ import {
   useUnconditionalStimulus,
   UnconditionalStimulusRef,
 } from '@utils/hooks'
+import { BreakStartContainer } from './BreakStartContainer'
+import { BreakEndContainer } from './BreakEndContainer'
 
 const ExperimentModuleTypes = {
   BASIC_INFO: BasicInfoContainer,
@@ -44,6 +46,8 @@ const ExperimentModuleTypes = {
   FEAR_CONDITIONING: FearConditioningContainer,
   AFFECTIVE_RATING: AffectiveRatingContainer,
   TEXT: TextContainer,
+  BREAK_START: BreakStartContainer,
+  BREAK_END: BreakEndContainer,
 }
 
 type ExperimentModuleConfig = {
@@ -104,7 +108,7 @@ export const ExperimentContainer = () => {
   const experiment = useSelector(experimentSelector)
   const experimentModules = useSelector(allModulesSelector)
   const currentModule = useSelector(currentModuleSelector)
-  const usRef = useUnconditionalStimulus(experiment)
+  const usRef = useUnconditionalStimulus()
 
   // If the user has been 'screened out' then show respective screen
   if (experiment.rejectionReason) {

--- a/src/redux/reducers/experiment.ts
+++ b/src/redux/reducers/experiment.ts
@@ -19,6 +19,7 @@ export type ExperimentCache = {
   headphoneType?: HeadphoneType
   volume?: number
   contactEmail?: string
+  breakEndDate?: Date
   isComplete: boolean
 }
 

--- a/src/screens/BreakEndScreen.tsx
+++ b/src/screens/BreakEndScreen.tsx
@@ -1,0 +1,80 @@
+import { Box, Text, Button, SafeAreaView } from '@components'
+
+type BreakEndScreenProps = {
+  heading: string
+  description: string
+  timerText: string
+  eta: string
+  extendedTimerText: string
+  buttonDisabled: boolean
+  actionLabel: string
+  onNext: () => void
+}
+
+export const BreakEndScreen: React.FunctionComponent<BreakEndScreenProps> = ({
+  eta,
+  heading,
+  timerText,
+  extendedTimerText,
+  description,
+  actionLabel,
+  buttonDisabled = false,
+  onNext,
+}) => {
+
+  return (
+    <SafeAreaView flex={1}>
+      <Box
+        flex={1}
+        alignItems="center"
+        justifyContent="flex-start"
+        pt={{ s: 8, m: 12 }}
+        px={5}
+      >
+        <Text variant="instructionHeading" mb={10}>
+          {heading}
+        </Text>
+
+        <Text variant="instructionDescription" mb={16} textAlign='left'>
+          {description}
+        </Text>
+
+        <Text variant="caption2" fontWeight='600' pb={2}>
+          Time Left:
+        </Text>
+
+        {timerText && (
+          <Text fontWeight='800' textAlign='center' fontSize={45}>
+            {timerText}
+          </Text>
+        )}
+
+        {extendedTimerText && (
+          <Text fontWeight='800' textAlign='center' fontSize={20}>
+            {extendedTimerText}
+          </Text>
+        )}
+
+        {eta && (
+          <Text variant="caption2" fontWeight='600' pt={10}>
+            ETA: {eta}
+          </Text>
+        )}
+
+        <Box flex={1} justifyContent="flex-end" pb={6}>
+          <Text variant="caption2" px={4} mb={3} textAlign="center">
+            {actionLabel}
+          </Text>
+
+          <Button
+            variant="primary"
+            label="Next"
+            onPress={onNext}
+            opacity={buttonDisabled ? 0.4 : 1}
+            disabled={buttonDisabled}
+          />
+        </Box>
+      </Box>
+    </SafeAreaView>
+  )
+}

--- a/src/screens/BreakEndScreen.tsx
+++ b/src/screens/BreakEndScreen.tsx
@@ -1,3 +1,4 @@
+import { ScrollView } from 'react-native'
 import { Box, Text, Button, SafeAreaView } from '@components'
 
 type BreakEndScreenProps = {
@@ -23,58 +24,64 @@ export const BreakEndScreen: React.FunctionComponent<BreakEndScreenProps> = ({
 }) => {
 
   return (
-    <SafeAreaView flex={1}>
-      <Box
-        flex={1}
-        alignItems="center"
-        justifyContent="flex-start"
-        pt={{ s: 8, m: 12 }}
-        px={5}
-      >
-        <Text variant="instructionHeading" mb={10}>
-          {heading}
-        </Text>
+    <ScrollView contentContainerStyle={{ flexGrow: 1 }}>
+        <SafeAreaView flex={1}>
+          <Box
+            flex={1}
+            alignItems="center"
+            justifyContent="flex-start"
+            pt={{ s: 8, m: 12 }}
+            px={5}
+          >
+            { heading && (
+              <Text variant="instructionHeading" mb={10}>
+                {heading}
+              </Text>
+            )}
 
-        <Text variant="instructionDescription" mb={16} textAlign='left'>
-          {description}
-        </Text>
+            { description && (
+              <Text variant="instructionDescription" mb={16} textAlign='left'>
+                {description}
+              </Text>
+            )}
 
-        <Text variant="caption2" fontWeight='600' pb={2}>
-          Time Left:
-        </Text>
+            <Text variant="caption2" fontWeight='600' pb={2}>
+              Time Left:
+            </Text>
 
-        {timerText && (
-          <Text fontWeight='800' textAlign='center' fontSize={45}>
-            {timerText}
-          </Text>
-        )}
+            {timerText && (
+              <Text fontWeight='800' textAlign='center' fontSize={45}>
+                {timerText}
+              </Text>
+            )}
 
-        {extendedTimerText && (
-          <Text fontWeight='800' textAlign='center' fontSize={20}>
-            {extendedTimerText}
-          </Text>
-        )}
+            {extendedTimerText && (
+              <Text fontWeight='800' textAlign='center' fontSize={20}>
+                {extendedTimerText}
+              </Text>
+            )}
 
-        {eta && (
-          <Text variant="caption2" fontWeight='600' pt={10}>
-            ETA: {eta}
-          </Text>
-        )}
+            {eta && (
+              <Text variant="caption2" fontWeight='600' pt={10}>
+                ETA: {eta}
+              </Text>
+            )}
 
-        <Box flex={1} justifyContent="flex-end" pb={6}>
-          <Text variant="caption2" px={4} mb={3} textAlign="center">
-            {actionLabel}
-          </Text>
+            <Box flex={1} justifyContent="flex-end" pb={6}>
+              <Text variant="caption2" px={4} mb={3} textAlign="center">
+                {actionLabel}
+              </Text>
 
-          <Button
-            variant="primary"
-            label="Next"
-            onPress={onNext}
-            opacity={buttonDisabled ? 0.4 : 1}
-            disabled={buttonDisabled}
-          />
-        </Box>
-      </Box>
-    </SafeAreaView>
+              <Button
+                variant="primary"
+                label="Next"
+                onPress={onNext}
+                opacity={buttonDisabled ? 0.4 : 1}
+                disabled={buttonDisabled}
+              />
+            </Box>
+          </Box>
+        </SafeAreaView>
+    </ScrollView>
   )
 }

--- a/src/screens/BreakEndScreen.tsx
+++ b/src/screens/BreakEndScreen.tsx
@@ -22,66 +22,65 @@ export const BreakEndScreen: React.FunctionComponent<BreakEndScreenProps> = ({
   buttonDisabled = false,
   onNext,
 }) => {
-
   return (
     <ScrollView contentContainerStyle={{ flexGrow: 1 }}>
-        <SafeAreaView flex={1}>
-          <Box
-            flex={1}
-            alignItems="center"
-            justifyContent="flex-start"
-            pt={{ s: 8, m: 12 }}
-            px={5}
-          >
-            { heading && (
-              <Text variant="instructionHeading" mb={10}>
-                {heading}
-              </Text>
-            )}
+      <SafeAreaView flex={1}>
+        <Box
+          flex={1}
+          alignItems="center"
+          justifyContent="flex-start"
+          pt={{ s: 8, m: 12 }}
+          px={5}
+        >
+          {heading && (
+            <Text variant="instructionHeading" mb={10}>
+              {heading}
+            </Text>
+          )}
 
-            { description && (
-              <Text variant="instructionDescription" mb={16} textAlign='left'>
-                {description}
-              </Text>
-            )}
+          {description && (
+            <Text variant="instructionDescription" mb={16} textAlign="left">
+              {description}
+            </Text>
+          )}
 
-            <Text variant="caption2" fontWeight='600' pb={2}>
-              Time Left:
+          <Text variant="caption2" fontWeight="600" pb={2}>
+            Time Left:
+          </Text>
+
+          {timerText && (
+            <Text fontWeight="800" textAlign="center" fontSize={45}>
+              {timerText}
+            </Text>
+          )}
+
+          {extendedTimerText && (
+            <Text fontWeight="800" textAlign="center" fontSize={20}>
+              {extendedTimerText}
+            </Text>
+          )}
+
+          {eta && (
+            <Text variant="caption2" fontWeight="600" pt={10}>
+              ETA: {eta}
+            </Text>
+          )}
+
+          <Box flex={1} justifyContent="flex-end" pb={6}>
+            <Text variant="caption2" px={4} mb={3} textAlign="center">
+              {actionLabel}
             </Text>
 
-            {timerText && (
-              <Text fontWeight='800' textAlign='center' fontSize={45}>
-                {timerText}
-              </Text>
-            )}
-
-            {extendedTimerText && (
-              <Text fontWeight='800' textAlign='center' fontSize={20}>
-                {extendedTimerText}
-              </Text>
-            )}
-
-            {eta && (
-              <Text variant="caption2" fontWeight='600' pt={10}>
-                ETA: {eta}
-              </Text>
-            )}
-
-            <Box flex={1} justifyContent="flex-end" pb={6}>
-              <Text variant="caption2" px={4} mb={3} textAlign="center">
-                {actionLabel}
-              </Text>
-
-              <Button
-                variant="primary"
-                label="Next"
-                onPress={onNext}
-                opacity={buttonDisabled ? 0.4 : 1}
-                disabled={buttonDisabled}
-              />
-            </Box>
+            <Button
+              variant="primary"
+              label="Next"
+              onPress={onNext}
+              opacity={buttonDisabled ? 0.4 : 1}
+              disabled={buttonDisabled}
+            />
           </Box>
-        </SafeAreaView>
+        </Box>
+      </SafeAreaView>
     </ScrollView>
   )
 }

--- a/src/screens/TextInstructionScreen.tsx
+++ b/src/screens/TextInstructionScreen.tsx
@@ -10,6 +10,7 @@ type TextInstructionScreenProps = {
   textColor?: ThemeColors
   linkColor?: ThemeColors
   textAlign?: string
+  buttonDisabled?: boolean
   onNext: () => void
 }
 
@@ -22,6 +23,7 @@ export const TextInstructionScreen: React.FunctionComponent<TextInstructionScree
   backgroundColor = 'pureWhite',
   linkColor = 'pureWhite',
   textAlign = 'center',
+  buttonDisabled = false,
   onNext,
 }) => {
   return (
@@ -47,7 +49,13 @@ export const TextInstructionScreen: React.FunctionComponent<TextInstructionScree
 
         <Box flex={1} justifyContent="flex-end" pb={6}>
           {actionLabel && (
-            <Text variant="caption2" px={6} mb={4} color={textColor}>
+            <Text
+              variant="caption2"
+              px={6}
+              mb={4}
+              color={textColor}
+              textAlign="center"
+            >
               {actionLabel}
             </Text>
           )}
@@ -57,6 +65,8 @@ export const TextInstructionScreen: React.FunctionComponent<TextInstructionScree
             label="Next"
             backgroundColor={color}
             onPress={onNext}
+            opacity={buttonDisabled ? 0.4 : 1}
+            disabled={buttonDisabled}
             textProps={{
               color: linkColor,
             }}

--- a/src/utils/AppStateMonitor.ts
+++ b/src/utils/AppStateMonitor.ts
@@ -1,4 +1,4 @@
-import { Alert, AppState as NativeAppState } from 'react-native'
+import { AppState as NativeAppState } from 'react-native'
 
 import { store } from '@redux/store'
 import {
@@ -8,6 +8,7 @@ import {
   recordEvent,
   rejectParticipant,
 } from '@redux/reducers'
+import { isPast } from 'date-fns'
 import { currentModuleSelector, experimentSelector } from '@redux/selectors'
 
 const SUSPENDED_TIMEOUT = 60000
@@ -57,13 +58,18 @@ export default class AppStateMonitor {
 
       // Trigger flag if the user had the app suspended for too long.
       if (
-        !experiment.isComplete &&
-        (suspendedTime > SUSPENDED_TIMEOUT ||
-          (applyStrictTimeout && suspendedTime > STRICT_SUSPENED_TIMEOUT))
+        experiment.breakEndDate === undefined ||
+        isPast(experiment.breakEndDate)
       ) {
-        store.dispatch(
-          rejectParticipant(applyStrictTimeout ? 'TRIAL_TIMEOUT' : 'TIMEOUT'),
-        )
+        if (
+          !experiment.isComplete &&
+          (suspendedTime > SUSPENDED_TIMEOUT ||
+            (applyStrictTimeout && suspendedTime > STRICT_SUSPENED_TIMEOUT))
+        ) {
+          store.dispatch(
+            rejectParticipant(applyStrictTimeout ? 'TRIAL_TIMEOUT' : 'TIMEOUT'),
+          )
+        }
       }
     }
 

--- a/src/utils/AppStateMonitor.ts
+++ b/src/utils/AppStateMonitor.ts
@@ -57,19 +57,16 @@ export default class AppStateMonitor {
         currentModule?.moduleType === 'FEAR_CONDITIONING'
 
       // Trigger flag if the user had the app suspended for too long.
-      if (
-        experiment.breakEndDate === undefined ||
-        isPast(experiment.breakEndDate)
-      ) {
-        if (
-          !experiment.isComplete &&
-          (suspendedTime > SUSPENDED_TIMEOUT ||
-            (applyStrictTimeout && suspendedTime > STRICT_SUSPENED_TIMEOUT))
-        ) {
-          store.dispatch(
-            rejectParticipant(applyStrictTimeout ? 'TRIAL_TIMEOUT' : 'TIMEOUT'),
-          )
-        }
+      const breakExpired =
+        experiment.breakEndDate === undefined || isPast(experiment.breakEndDate)
+      const timeoutTriggered =
+        !experiment.isComplete &&
+        (suspendedTime > SUSPENDED_TIMEOUT ||
+          (applyStrictTimeout && suspendedTime > STRICT_SUSPENED_TIMEOUT))
+      if (timeoutTriggered && breakExpired) {
+        store.dispatch(
+          rejectParticipant(applyStrictTimeout ? 'TRIAL_TIMEOUT' : 'TIMEOUT'),
+        )
       }
     }
 

--- a/src/utils/exampleExperiment.ts
+++ b/src/utils/exampleExperiment.ts
@@ -167,7 +167,8 @@ export const exampleExperimentData: Experiment = {
       moduleType: 'BREAK_START',
       definition: {
         startTitle: 'Break Time',
-        startBody: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum dictum massa blandit nisi auctor placerat. Suspendisse fermentum enim non hendrerit elementum. In condimentum pharetra imperdiet. Fusce auctor eros eu finibus aliquam. Donec vel tortor tempus, condimentum augue ornare, molestie tortor.',
+        startBody:
+          'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum dictum massa blandit nisi auctor placerat. Suspendisse fermentum enim non hendrerit elementum. In condimentum pharetra imperdiet. Fusce auctor eros eu finibus aliquam. Donec vel tortor tempus, condimentum augue ornare, molestie tortor.',
         duration: 60,
         endModule: 234,
       },
@@ -188,7 +189,8 @@ export const exampleExperimentData: Experiment = {
       definition: {
         startModule: 123,
         endTitle: 'End of Break',
-        endBody: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum dictum massa blandit nisi auctor placerat. Suspendisse fermentum enim non hendrerit elementum. In condimentum pharetra imperdiet. Fusce auctor eros eu finibus aliquam. Donec vel tortor tempus, condimentum augue ornare, molestie tortor.',
+        endBody:
+          'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum dictum massa blandit nisi auctor placerat. Suspendisse fermentum enim non hendrerit elementum. In condimentum pharetra imperdiet. Fusce auctor eros eu finibus aliquam. Donec vel tortor tempus, condimentum augue ornare, molestie tortor.',
       },
     },
   ],

--- a/src/utils/exampleExperiment.ts
+++ b/src/utils/exampleExperiment.ts
@@ -163,14 +163,32 @@ export const exampleExperimentData: Experiment = {
       },
     },
     {
+      id: '34684',
+      moduleType: 'BREAK_START',
+      definition: {
+        startTitle: 'Break Time',
+        startBody: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum dictum massa blandit nisi auctor placerat. Suspendisse fermentum enim non hendrerit elementum. In condimentum pharetra imperdiet. Fusce auctor eros eu finibus aliquam. Donec vel tortor tempus, condimentum augue ornare, molestie tortor.',
+        duration: 60,
+        endModule: 234,
+      },
+    },
+    {
       id: '564651',
       moduleType: 'WEB',
       definition: {
         heading: 'FLARe Questionnaire',
         description: `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc in dui quis odio volutpat pulvinar eu id eros. In ut ipsum ac ipsum varius scelerisque. Pellentesque nec neque vel odio tempor aliquam. Aliquam rutrum vestibulum ligula, eget viverra mauris porta id.`,
-        url: 'https://kclbs.eu.qualtrics.com/jfe/form/SV_802kLj0WlUSVByd',
-        appendParticipantId: true,
-        autoCloseUrl: 'http://flare-portal.staging.torchbox.com/redirect',
+        url: 'https://google.com',
+      },
+    },
+
+    {
+      id: '34687',
+      moduleType: 'BREAK_END',
+      definition: {
+        startModule: 123,
+        endTitle: 'End of Break',
+        endBody: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum dictum massa blandit nisi auctor placerat. Suspendisse fermentum enim non hendrerit elementum. In condimentum pharetra imperdiet. Fusce auctor eros eu finibus aliquam. Donec vel tortor tempus, condimentum augue ornare, molestie tortor.',
       },
     },
   ],


### PR DESCRIPTION
This PR add's the break module which consists of two screens, A start and end screen. The start screen activates the break while the end has a countdown till the end of the break. Starting a break will stop the app from timing out.

The countdown timer has 3 states:
- Break Finished
- Hours/Mins/Secs countdown timer (for periods <24 hours)
- Long Countdown: `6 days 23 hours 58 minutes`

## Screenshots:
![Simulator Screen Shot - iPhone 11 Pro - 2021-01-15 at 09 11 02](https://user-images.githubusercontent.com/13197111/104705661-1ba8b080-5712-11eb-8281-1ac575b23d4e.png)
![Simulator Screen Shot - iPhone 11 Pro - 2021-01-15 at 09 13 12](https://user-images.githubusercontent.com/13197111/104705668-1d727400-5712-11eb-8ed3-f1a04ec08a46.png)
![Simulator Screen Shot - iPhone 11 Pro - 2021-01-15 at 09 13 23](https://user-images.githubusercontent.com/13197111/104705670-1e0b0a80-5712-11eb-9f67-f535c0afe595.png)
![Simulator Screen Shot - iPhone 11 Pro - 2021-01-15 at 09 16 22](https://user-images.githubusercontent.com/13197111/104705899-5ca0c500-5712-11eb-87ea-2f76f0a981e4.png)

