### PR TITLE
Fix logic issue in CriteriaScreen

### DIFF
--- a/src/screens/CriteriaScreen.tsx
+++ b/src/screens/CriteriaScreen.tsx
@@ -78,13 +78,11 @@ export const CriteriaScreen: React.FunctionComponent<CriteriaScreenParams> = ({
     // Check if any of the answers make participant incompatible
     const invalidCriterion = consentCriteria.find(
       (criterion) =>
-        criterion.requiredAnswer != null &&
-        criterion.value != criterion.requiredAnswer,
+        (criterion.value != null && criterion.value != criterion.requiredAnswer)
     )
 
     // Proceed or redirect
     if (invalidCriterion) {
-      // In future will be handled by ViewController
       onFailCriteria()
     } else {
       onPassCriteria(consentCriteria)


### PR DESCRIPTION
This is a one line PR that fixes the issue where criterions that aren't required cause termination logic.