### PR TITLE
#131: Update summary sync screen

### DIFF
--- a/src/screens/SummaryScreen.tsx
+++ b/src/screens/SummaryScreen.tsx
@@ -20,8 +20,7 @@ export const SummaryScreen: React.FC<SummaryScreenProps> = ({
 }) => {
   const [isSyncing, setIsSyncing] = useState<boolean>(false)
   const netInfo = useNetInfo()
-  const allModulesSynced =
-    modules.filter((modules) => !modules.moduleCompleted).length === 0
+  const allModulesSynced = false
 
   const syncExperimentAnimated = async () => {
     // Start animation
@@ -61,14 +60,14 @@ export const SummaryScreen: React.FC<SummaryScreenProps> = ({
               connection.
             </Text>
 
-            {isSyncing && !allModulesSynced ? (
+            {isSyncing ? (
               <Spinner
                 isVisible
                 size={100}
                 type="WanderingCubes"
                 color={palette.purple}
               />
-            ) : (
+            ) : allModulesSynced && (
               <AntDesign
                 name="checkcircle"
                 size={90}

--- a/src/screens/SummaryScreen.tsx
+++ b/src/screens/SummaryScreen.tsx
@@ -34,7 +34,9 @@ export const SummaryScreen: React.FC<SummaryScreenProps> = ({
   // Trigger sync when connection is stable
   useEffect(() => {
     if (netInfo.isInternetReachable) {
-      syncExperimentAnimated()
+      if (isSyncing === false) {
+        syncExperimentAnimated()
+      }
     }
   }, [netInfo.isInternetReachable])
 
@@ -60,19 +62,21 @@ export const SummaryScreen: React.FC<SummaryScreenProps> = ({
               connection.
             </Text>
 
-            {isSyncing ? (
+            {true ? (
               <Spinner
                 isVisible
                 size={100}
                 type="WanderingCubes"
                 color={palette.purple}
               />
-            ) : allModulesSynced && (
-              <AntDesign
-                name="checkcircle"
-                size={90}
-                color={palette.greenCorrect}
-              />
+            ) : (
+              allModulesSynced && (
+                <AntDesign
+                  name="checkcircle"
+                  size={90}
+                  color={palette.greenCorrect}
+                />
+              )
             )}
           </Box>
 
@@ -102,7 +106,7 @@ export const SummaryScreen: React.FC<SummaryScreenProps> = ({
               label="Sync Now"
               variant="primary"
               backgroundColor="coral"
-              disabled={!allModulesSynced}
+              disabled={!allModulesSynced && !isSyncing}
               opacity={allModulesSynced ? 0 : 1}
               onPress={() => syncExperimentAnimated()}
             />


### PR DESCRIPTION
This PR updates the design on the experiment summary screen that stops the user progressing if their data hasn't been submitted to the portal.

## Screenshots

![Simulator Screen Shot - iPhone 12 Pro - 2021-01-18 at 16 38 28](https://user-images.githubusercontent.com/13197111/104942065-d9020500-59ab-11eb-8ad8-bf8c68128c90.png)
![Simulator Screen Shot - iPhone 12 Pro - 2021-01-18 at 16 38 01](https://user-images.githubusercontent.com/13197111/104942066-d99a9b80-59ab-11eb-91fd-f1d65b6e3166.png)
![Simulator Screen Shot - iPhone 12 Pro - 2021-01-18 at 16 37 02](https://user-images.githubusercontent.com/13197111/104942068-da333200-59ab-11eb-90bb-a974c7e20bd3.png)

