### PR TITLE
#137: Fix anchor labels for task instructions

### DIFF
--- a/src/containers/ExperimentContainer.tsx
+++ b/src/containers/ExperimentContainer.tsx
@@ -65,6 +65,12 @@ export type VisualStimuli = {
   label: string
 }
 
+export type AnchorLabels = {
+  anchorLabelLeft?: string
+  anchorLabelCenter?: string
+  anchorLabelRight?: string
+}
+
 export type Experiment = {
   id: number
   name: string

--- a/src/containers/TaskInstructionsContainer.tsx
+++ b/src/containers/TaskInstructionsContainer.tsx
@@ -7,6 +7,7 @@ import {
   RatingPracticeScreen,
   IntervalExplainationScreen,
 } from '@screens'
+import { AnchorLabels } from '@containers/ExperimentContainer'
 
 type TaskInstructionsModuleDefinition = {
   // Screen 1
@@ -50,6 +51,12 @@ export const TaskInstructionsContainer: ExperimentModule<TaskInstructionsModuleS
   const onNextInstruction = () =>
     updateModule({ currentInstruction: mod.currentInstruction + 1 })
 
+  const anchorLabels: AnchorLabels = {
+    anchorLabelLeft: experiment.definition.ratingScaleAnchorLabelLeft,
+    anchorLabelCenter: experiment.definition.ratingScaleAnchorLabelCenter,
+    anchorLabelRight: experiment.definition.ratingScaleAnchorLabelRight,
+  }
+
   const taskInstructions = [
     (key) => (
       <TextInstructionScreen
@@ -66,6 +73,7 @@ export const TaskInstructionsContainer: ExperimentModule<TaskInstructionsModuleS
         key={key}
         heading={mod.ratingExplanationHeading}
         description={mod.ratingExplanationBody}
+        anchorLabels={anchorLabels}
         color="teal"
         textAlign="center"
         onNext={onNextInstruction}
@@ -75,6 +83,7 @@ export const TaskInstructionsContainer: ExperimentModule<TaskInstructionsModuleS
       <RatingPracticeScreen
         key={key}
         heading={mod.ratingPracticeHeading}
+        anchorLabels={anchorLabels}
         color="teal"
         onNext={onNextInstruction}
       />

--- a/src/screens/RatingExplainationScreen.tsx
+++ b/src/screens/RatingExplainationScreen.tsx
@@ -1,7 +1,6 @@
 import { Box, Text, Button, RatingScale, SafeAreaView } from '@components'
 import { AnchorLabels } from '@containers/ExperimentContainer'
 
-
 type RatingExplainationScreenProps = {
   heading: string
   description: string

--- a/src/screens/RatingExplainationScreen.tsx
+++ b/src/screens/RatingExplainationScreen.tsx
@@ -1,10 +1,13 @@
 import { Box, Text, Button, RatingScale, SafeAreaView } from '@components'
+import { AnchorLabels } from '@containers/ExperimentContainer'
+
 
 type RatingExplainationScreenProps = {
   heading: string
   description: string
   actionLabel?: string
   color?: string
+  anchorLabels: AnchorLabels
   onNext: () => void
 }
 
@@ -13,6 +16,7 @@ export const RatingExplainationScreen: React.FunctionComponent<RatingExplainatio
   description,
   actionLabel,
   color = 'purple',
+  anchorLabels,
   onNext,
 }) => {
   return (
@@ -36,7 +40,7 @@ export const RatingExplainationScreen: React.FunctionComponent<RatingExplainatio
           {heading}
         </Text>
 
-        <RatingScale disabled />
+        <RatingScale disabled {...anchorLabels} />
 
         <Text
           variant="instructionDescription"

--- a/src/screens/RatingPracticeScreen.tsx
+++ b/src/screens/RatingPracticeScreen.tsx
@@ -1,15 +1,18 @@
 import { useState } from 'react'
 import { Box, Text, Button, RatingScale, SafeAreaView } from '@components'
+import { AnchorLabels } from '@containers/ExperimentContainer'
 
 type RatingPracticeScreenProps = {
   heading: string
   color?: string
+  anchorLabels: AnchorLabels
   onNext: () => void
 }
 
 export const RatingPracticeScreen: React.FunctionComponent<RatingPracticeScreenProps> = ({
   heading,
   color = 'purple',
+  anchorLabels,
   onNext,
 }) => {
   const [showButton, setShowButton] = useState(false)
@@ -36,6 +39,7 @@ export const RatingPracticeScreen: React.FunctionComponent<RatingPracticeScreenP
         </Text>
 
         <RatingScale
+          {...anchorLabels}
           lockFirstRating
           onChange={() => {
             setShowButton(true)


### PR DESCRIPTION
This PR passes the global anchor labels to the rating instruction screens.