### PR TITLE
Allow trial to be stopped by headphones

### DIFF
--- a/src/components/Alert.tsx
+++ b/src/components/Alert.tsx
@@ -71,7 +71,7 @@ export const Alert: React.FC<AlertProps> = ({
               pb={6}
               zIndex={120}
             >
-              {actions.length > 0 ? (
+              {actions != undefined ? (
                 actions.map((props) => (
                   <AlertButton alertRef={alertRef} {...props} />
                 ))

--- a/src/containers/ExperimentContainer.tsx
+++ b/src/containers/ExperimentContainer.tsx
@@ -125,20 +125,20 @@ export const ExperimentContainer = () => {
 
   // If the user has been 'screened out' then show respective screen
   if (experiment.rejectionReason) {
-    if (allModulesSynced && !experiment.offlineOnly) {
-      return (
-        <RejectionScreen
-          contactLink={experiment.contactEmail}
-          reason={experiment.rejectionReason}
-          onExit={() => terminateExperiment(false)}
-        />
-      )
-    } else {
+    if (!allModulesSynced && !experiment.offlineOnly) {
       return (
         <SummaryScreen
           allModulesSynced={allModulesSynced}
           syncExperiment={() => dispatch(syncExperiment)}
           onExit={() => null}
+        />
+      )
+    } else {
+      return (
+        <RejectionScreen
+          contactLink={experiment.contactEmail}
+          reason={experiment.rejectionReason}
+          onExit={() => terminateExperiment(false)}
         />
       )
     }

--- a/src/utils/AlertProvider.tsx
+++ b/src/utils/AlertProvider.tsx
@@ -67,7 +67,7 @@ export const useAlert = (): AlertInterface => {
   const dispatch = useDispatch()
 
   return {
-    alert: (title, description, actions = [], color = 'red') => {
+    alert: (title, description, actions, color = 'red') => {
       // Create alert
       const alert: AlertRecord = {
         id: uuidv4(),

--- a/src/utils/timers.ts
+++ b/src/utils/timers.ts
@@ -1,0 +1,35 @@
+export class PauseableTimer {
+  timer = null
+  callback: () => void
+  timeRemaining: number
+  lastUpdated: number
+
+  constructor(callback: () => void, delay: number) {
+    // Create new timer
+    this.callback = callback
+    this.timeRemaining = delay
+    this.resume()
+  }
+
+  pause() {
+    if (this.timer != null) {
+      clearTimeout(this.timer)
+      this.timer = null
+      this.timeRemaining = this.timeRemaining - (Date.now() - this.lastUpdated)
+      this.lastUpdated = Date.now()
+    }
+  }
+
+  resume() {
+    if (this.timeRemaining >= 0 && this.timer === null) {
+      this.timer = setTimeout(this.callback, this.timeRemaining)
+      this.lastUpdated = Date.now()
+    }
+  }
+
+  destroy() {
+    clearTimeout(this.timer)
+    this.timer = null
+    this.timeRemaining = -1
+  }
+}


### PR DESCRIPTION
This PR pauses the timer when the users unplug their headphones or suspend the app to the background. It works by switching the `setTimeout` calls to a custom class called `PauseableTimer`.