### PR TITLE
Fix duplicate notifications

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,10 +12,7 @@ import { store, peristor } from '@redux/store'
 import { onStateHydrated } from '@redux/persist'
 import { ExperimentContainer } from 'containers/ExperimentContainer'
 import { AlertProvider } from '@utils/AlertProvider'
-import {
-  registerNotifications,
-  scheduleNotification,
-} from '@utils/notifications'
+import { registerNotifications } from '@utils/notifications'
 
 // Link with Sentry
 Sentry.init({

--- a/src/containers/BreakStartContainer.tsx
+++ b/src/containers/BreakStartContainer.tsx
@@ -8,10 +8,12 @@ export type BreakStartModuleState = {
   startTitle: string
   startBody: string
   duration: number
+  notificationScheduled: boolean
 }
 
 export const BreakStartContainer: ExperimentModule<BreakStartModuleState> = ({
   module: mod,
+  updateModule,
   onModuleComplete,
   updateExperiment,
 }) => {
@@ -21,13 +23,18 @@ export const BreakStartContainer: ExperimentModule<BreakStartModuleState> = ({
     // Update State
     updateExperiment({ breakEndDate })
 
-    // Add notification alerts
-    scheduleNotification('BREAK_OVER', breakEndDate)
+    if (!mod.notificationScheduled) {
+      // Add notification alerts
+      scheduleNotification('BREAK_OVER', breakEndDate)
 
-    // Add warning notification 2 hours before end if break is over 4 hours
-    if (mod.duration >= 14400) {
-      const reminderDate = subHours(breakEndDate, 2)
-      scheduleNotification('BREAK_OVER_APPROACHING', reminderDate)
+      // Add warning notification 2 hours before end if break is over 4 hours
+      if (mod.duration >= 14400) {
+        const reminderDate = subHours(breakEndDate, 2)
+        scheduleNotification('BREAK_OVER_APPROACHING', reminderDate)
+      }
+
+      // Set flag to stop duplicate notifications
+      updateModule({ notificationScheduled: true })
     }
   }, [])
 

--- a/src/containers/ExperimentContainer.tsx
+++ b/src/containers/ExperimentContainer.tsx
@@ -2,6 +2,7 @@ import { ImageSourcePropType } from 'react-native'
 import { useDispatch, useSelector } from 'react-redux'
 import { AVPlaybackSource } from 'expo-av/build/AV'
 import {
+  moduleSelector,
   experimentSelector,
   currentModuleSelector,
   allModulesSelector,
@@ -126,19 +127,16 @@ export const ExperimentContainer = () => {
   const experiment: ExperimentCache = useSelector(experimentSelector)
   const experimentModules = useSelector(allModulesSelector)
   let currentModule = useSelector(currentModuleSelector)
+  const summaryModule = useSelector(store => moduleSelector(store, 'SummaryModule'))
   const allModulesSynced = useSelector(allModulesSyncedSelector)
   const usRef = useUnconditionalStimulus()
 
   // If the user has been 'screened out' then show respective screen
   if (experiment.rejectionReason) {
     if (!allModulesSynced && !experiment.offlineOnly) {
-      return (
-        <SummaryScreen
-          allModulesSynced={allModulesSynced}
-          syncExperiment={() => dispatch(syncExperiment)}
-          onExit={() => null}
-        />
-      )
+      // Set the sync as the next module
+      updateExperimentState({ currentModuleIndex: summaryModule.index })
+      return
     } else {
       return (
         <RejectionScreen
@@ -232,6 +230,7 @@ export const ExperimentContainer = () => {
   function updateModuleState(updatedModuleState) {
     dispatch(
       updateModule({
+        index: currentModule.index,
         moduleId: currentModule.moduleId,
         moduleState: {
           ...currentModule.moduleState,
@@ -243,7 +242,7 @@ export const ExperimentContainer = () => {
   }
 
   // Function used to update the global defenition of the experiment
-  function updateExperimentState(updatedExperimentState) {
+  function updateExperimentState(updatedExperimentState: Partial<ExperimentCache>) {
     dispatch(updateExperiment(updatedExperimentState))
   }
 

--- a/src/containers/SummaryContainer.tsx
+++ b/src/containers/SummaryContainer.tsx
@@ -3,7 +3,13 @@ import { SummaryScreen } from '@screens'
 import { ExperimentModule } from './ExperimentContainer'
 import { allModulesSyncedSelector } from '@redux/selectors'
 
-export const SummaryContainer: ExperimentModule = ({
+type SummaryContainerState = {
+  notificationsScheduled: boolean
+}
+
+export const SummaryContainer: ExperimentModule<SummaryContainerState> = ({
+  module: mod,
+  updateModule,
   onModuleComplete,
   syncExperiment,
 }) => {
@@ -12,6 +18,10 @@ export const SummaryContainer: ExperimentModule = ({
   return (
     <SummaryScreen
       allModulesSynced={allModulesSynced}
+      notificationsScheduled={mod.notificationsScheduled}
+      setNotificationsScheduled={() => updateModule({
+        notificationsScheduled: true
+      })}
       syncExperiment={syncExperiment}
       onExit={() => onModuleComplete()}
     />

--- a/src/screens/BreakStartScreen.tsx
+++ b/src/screens/BreakStartScreen.tsx
@@ -5,7 +5,7 @@ type BreakStartScreenProps = {
   heading: string
   description: string
 
-  buttonDisabled: boolean
+  buttonDisabled?: boolean
   actionLabel: string
   onNext: () => void
 }

--- a/src/screens/LoginScreen.tsx
+++ b/src/screens/LoginScreen.tsx
@@ -376,9 +376,10 @@ async function loginWithID(participantID: string, dispatch) {
 // Demo Mode Activation
 function demoLogin(dispatch) {
   // Save modules to redux
-  exampleExperimentData.modules.map((mod) => {
+  exampleExperimentData.modules.map((mod, index) => {
     dispatch(
       updateModule({
+        index,
         moduleId: mod.id,
         moduleType: mod.moduleType,
         moduleState: mod.definition,

--- a/src/screens/SummaryScreen.tsx
+++ b/src/screens/SummaryScreen.tsx
@@ -53,8 +53,8 @@ export const SummaryScreen: React.FC<SummaryScreenProps> = ({
     } else {
       if (!notificationsScheduled) {
         // Add notifications in 2 & 24 Hours
-        scheduleNotification('SYNC_REQUIRED', addMinutes(new Date(), 2))
-        scheduleNotification('SYNC_REQUIRED', addMinutes(new Date(), 24))
+        scheduleNotification('SYNC_REQUIRED', addHours(new Date(), 2))
+        scheduleNotification('SYNC_REQUIRED', addHours(new Date(), 24))
 
         // Set flag to stop duplicate notifications
         setNotificationsScheduled()

--- a/src/screens/SummaryScreen.tsx
+++ b/src/screens/SummaryScreen.tsx
@@ -16,15 +16,20 @@ import {
   cancelAllNotifications,
   scheduleNotification,
 } from '@utils/notifications'
+import { addMinutes } from 'date-fns/esm'
 
 type SummaryScreenProps = {
   allModulesSynced: boolean
+  notificationsScheduled: boolean
   syncExperiment: () => void
+  setNotificationsScheduled: () => void
   onExit: () => void
 }
 
 export const SummaryScreen: React.FC<SummaryScreenProps> = ({
+  notificationsScheduled,
   allModulesSynced,
+  setNotificationsScheduled,
   syncExperiment,
   onExit,
 }) => {
@@ -46,12 +51,14 @@ export const SummaryScreen: React.FC<SummaryScreenProps> = ({
         syncExperimentAnimated()
       }
     } else {
-      // Clear all sync notifications
-      cancelAllNotifications('SYNC_REQUIRED')
+      if (!notificationsScheduled) {
+        // Add notifications in 2 & 24 Hours
+        scheduleNotification('SYNC_REQUIRED', addMinutes(new Date(), 2))
+        scheduleNotification('SYNC_REQUIRED', addMinutes(new Date(), 24))
 
-      // Add notifications in 2 & 24 Hours
-      scheduleNotification('SYNC_REQUIRED', addHours(new Date(), 2))
-      scheduleNotification('SYNC_REQUIRED', addHours(new Date(), 24))
+        // Set flag to stop duplicate notifications
+        setNotificationsScheduled()
+      }
     }
 
     if (allModulesSynced) {


### PR DESCRIPTION
This PR makes sure that screens store in Redux when they schedule notifications. This is to stop duplicate notifications that can become very bothersome.