### PR TITLE
Add tracking functionality

### DIFF
--- a/src/containers/ExperimentContainer.tsx
+++ b/src/containers/ExperimentContainer.tsx
@@ -19,7 +19,7 @@ import {
   ExperimentCache,
   RejectionReason,
 } from '@redux/reducers'
-import { syncExperiment } from '@redux/actions'
+import { syncExperiment, syncExperimentProgress } from '@redux/actions'
 import { LoginScreen, RejectionScreen } from '@screens'
 import { TermsContainer } from './TermsContainer'
 import { CriterionContainer } from './CriterionContainer'
@@ -121,6 +121,7 @@ export type ExperimentModule<
     onModuleComplete: (module?: Partial<ModuleState>) => void
     unconditionalStimulus?: UnconditionalStimulusRef
     syncExperiment: () => void
+    syncExperimentProgress: () => void
     terminateExperiment: (boolean, RejectionReason) => void
     exitExperiment: (RejectionReason) => void
   }
@@ -239,6 +240,7 @@ export const ExperimentContainer = () => {
     // Set variable to show the terminated screen
     if (redirect) {
       dispatch(rejectParticipant(rejectionReason))
+      dispatch(syncExperimentProgress)
     }
   }
 
@@ -285,6 +287,7 @@ export const ExperimentContainer = () => {
         onModuleComplete={onModuleComplete}
         terminateExperiment={terminateExperiment}
         syncExperiment={() => dispatch(syncExperiment)}
+        syncExperimentProgress={() => dispatch(syncExperimentProgress)}
         unconditionalStimulus={usRef}
         exitExperiment={exitExperiment}
       />

--- a/src/containers/FearConditioningContainer.tsx
+++ b/src/containers/FearConditioningContainer.tsx
@@ -33,8 +33,8 @@ export const FearConditioningContainer: ExperimentModule<FearConditioningModuleS
   experiment,
   module: mod,
   updateModule,
-  exitExperiment,
   onModuleComplete,
+  syncExperimentProgress,
   unconditionalStimulus,
 }) => {
   const Alert = useAlert()
@@ -157,6 +157,9 @@ export const FearConditioningContainer: ExperimentModule<FearConditioningModuleS
       Math.random() * (intervalBounds.max - intervalBounds.min + 1) +
         intervalBounds.min,
     ) * 1000
+
+  // Update tracking
+  syncExperimentProgress()
 
   // Render the current trial
   const currentTrial = mod.trials[mod.currentTrialIndex]

--- a/src/redux/selectors.ts
+++ b/src/redux/selectors.ts
@@ -11,7 +11,9 @@ export const experimentSelector = (state: AppState): ExperimentCache =>
 export const moduleSelector = (state: AppState, moduleId) =>
   state.modules[moduleId]
 
-export const currentModuleSelector = (state: AppState) => {
+export const currentModuleSelector = (
+  state: AppState,
+): ExperimentModuleCache => {
   const currentIndex = state.experiment.currentModuleIndex
   return Object.values(state.modules).find(
     (mod: ExperimentModuleCache) => mod.index === currentIndex,

--- a/src/utils/PortalAPI.ts
+++ b/src/utils/PortalAPI.ts
@@ -46,6 +46,17 @@ export class PortalAPI {
     throw new Error(errMessage)
   }
 
+  static async submitProgress(trackingSubmission: PortalTrackingSubmission) {
+    // Convert object to string
+    const jsonData = JSON.stringify(trackingSubmission)
+    const response = await PortalAPI.executeAPIRequest('tracking', jsonData)
+
+    // If validation error
+    if (response.status === 400) {
+      PortalAPI.reportValidationError(response)
+    }
+  }
+
   static async submitTrialRating(ratingResponse: PortalTrialRatingSubmission) {
     // Convert object to string
     const jsonData = JSON.stringify(ratingResponse)
@@ -200,6 +211,13 @@ export class PortalAPI {
 
     return await response.json()
   }
+}
+
+type PortalTrackingSubmission = {
+  module: string
+  participant: string
+  trial_index: number | undefined
+  rejection_reason: string | undefined
 }
 
 type PortalTrialRatingSubmission = {


### PR DESCRIPTION
This PR add's an extra sync method that updates the portal with the following details:
- Current module ID
- Current FC trial index
- Rejection/Lockout Reasons

Example Video: https://torchbox.slack.com/files/U6DN73TK9/F01NGNYGNSC/cleanshot_2021-02-11_at_12.48.04.mp4

