### PR TITLE
Build custom picker modal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "react": "^16.14.0",
         "react-dom": "~16.13.0",
         "react-native": "~0.63.3",
+        "react-native-actions-sheet": "^0.4.2",
         "react-native-config": "^1.4.0",
         "react-native-date-picker": "^3.2.5",
         "react-native-dotenv": "^2.4.1",
@@ -18459,6 +18460,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/react-native-actions-sheet": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/react-native-actions-sheet/-/react-native-actions-sheet-0.4.2.tgz",
+      "integrity": "sha512-yeOOggOSAcj7/+U+TwFBhPLi820a1mKAPZcFyOSgJrkQOTpSKw9vnMpqO+ciBH0ngptQq/30CpAH+P+Di3EJ7g=="
     },
     "node_modules/react-native-config": {
       "version": "1.4.0",
@@ -37625,6 +37631,11 @@
           }
         }
       }
+    },
+    "react-native-actions-sheet": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/react-native-actions-sheet/-/react-native-actions-sheet-0.4.2.tgz",
+      "integrity": "sha512-yeOOggOSAcj7/+U+TwFBhPLi820a1mKAPZcFyOSgJrkQOTpSKw9vnMpqO+ciBH0ngptQq/30CpAH+P+Di3EJ7g=="
     },
     "react-native-config": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "react": "^16.14.0",
     "react-dom": "~16.13.0",
     "react-native": "~0.63.3",
+    "react-native-actions-sheet": "^0.4.2",
     "react-native-config": "^1.4.0",
     "react-native-date-picker": "^3.2.5",
     "react-native-dotenv": "^2.4.1",

--- a/src/components/Alert.tsx
+++ b/src/components/Alert.tsx
@@ -47,7 +47,7 @@ export const Alert: React.FC<AlertProps> = ({
         >
           <SafeAreaView flex={1}>
             {/* Alert Heading */}
-            <Text color="darkGrey" fontSize={28} fontFamily="Inter-Bold">
+            <Text color="darkGrey" fontSize={28} fontFamily="Inter-SemiBold">
               {title}
             </Text>
 

--- a/src/components/FormFields.tsx
+++ b/src/components/FormFields.tsx
@@ -1,9 +1,5 @@
 import { useRef } from 'react'
-import {
-  Dimensions,
-  TextInput,
-  TextInputProps,
-} from 'react-native'
+import { Dimensions, TextInput, TextInputProps } from 'react-native'
 import { Picker } from '@react-native-picker/picker'
 import DatePicker from 'react-native-date-picker'
 import ActionSheet from 'react-native-actions-sheet'
@@ -82,7 +78,12 @@ export const LabeledTextField: React.FC<FormFieldProps> = ({
   </Box>
 )
 
-export const LabeledDateField: React.FC<FormFieldProps> = ({ label, value, onChange, ...props }) => (
+export const LabeledDateField: React.FC<FormFieldProps> = ({
+  label,
+  value,
+  onChange,
+  ...props
+}) => (
   <Box width="100%" py={4} {...props}>
     <Text variant="heading3" pb={1}>
       {label}
@@ -102,13 +103,12 @@ export const LabeledDateField: React.FC<FormFieldProps> = ({ label, value, onCha
   </Box>
 )
 
-
 type PickerFieldProps = FormFieldProps & {
-  options: { value: string, label: string }[]
+  options: { value: string; label: string }[]
   placeholder?: string
 }
 
-export const LabeledPickerField: React.FC<PickerFieldProps>  = ({
+export const LabeledPickerField: React.FC<PickerFieldProps> = ({
   label,
   value,
   placeholder,
@@ -132,14 +132,27 @@ export const LabeledPickerField: React.FC<PickerFieldProps>  = ({
               </Text>
             )}
 
-            <Box height={50} flex={1} flexDirection='row' alignItems='center' borderWidth={2} borderColor='purple' paddingLeft={4} borderRadius='m'>
+            <Box
+              height={50}
+              flex={1}
+              flexDirection="row"
+              alignItems="center"
+              borderWidth={2}
+              borderColor="purple"
+              paddingLeft={4}
+              borderRadius="m"
+            >
               <Text fontSize={14}> {selectedLabel ?? placeholder} </Text>
             </Box>
           </Box>
         </Pressable>
       </Box>
 
-      <ActionSheet ref={actionSheetRef} defaultOverlayOpacity={0.8} delayActionSheetDraw={false}>
+      <ActionSheet
+        ref={actionSheetRef}
+        defaultOverlayOpacity={0.8}
+        delayActionSheetDraw={false}
+      >
         <Box px={{ s: 4, m: 6 }}>
           <Box
             flexDirection="row"
@@ -158,23 +171,23 @@ export const LabeledPickerField: React.FC<PickerFieldProps>  = ({
           </Box>
 
           {/* <ScrollView> */}
-            <Box minHeight={300} pb={10} maxHeight={maxHeight}>
-              {options.map((option) => (
-                <Pressable onPress={() => onChange(option.value)}>
-                  <Box
-                    backgroundColor="offWhite"
-                    borderRadius="s"
-                    mb={3}
-                    px={2}
-                    py={3}
-                    borderColor={option.value == value ? 'purple' : 'offWhite'}
-                    borderWidth={3}
-                  >
-                    <Text variant="selectLabel">{option.label}</Text>
-                  </Box>
-                </Pressable>
-              ))}
-            </Box>
+          <Box minHeight={300} pb={10} maxHeight={maxHeight}>
+            {options.map((option) => (
+              <Pressable onPress={() => onChange(option.value)}>
+                <Box
+                  backgroundColor="offWhite"
+                  borderRadius="s"
+                  mb={3}
+                  px={2}
+                  py={3}
+                  borderColor={option.value == value ? 'purple' : 'offWhite'}
+                  borderWidth={3}
+                >
+                  <Text variant="selectLabel">{option.label}</Text>
+                </Box>
+              </Pressable>
+            ))}
+          </Box>
           {/* </ScrollView> */}
         </Box>
       </ActionSheet>

--- a/src/components/FormFields.tsx
+++ b/src/components/FormFields.tsx
@@ -43,7 +43,7 @@ export const TextField = createRestyleComponent<Props, Theme>(
 
 type FormFieldProps = BoxProps<Theme> & {
   label: string
-  value: any
+  value: string | number
   onChange?: (string) => void
   onTap?: () => void
   labelProps?: TextProps<Theme>

--- a/src/components/FormFields.tsx
+++ b/src/components/FormFields.tsx
@@ -1,6 +1,12 @@
-import { TextInput, TextInputProps } from 'react-native'
+import { useRef } from 'react'
+import {
+  Dimensions,
+  TextInput,
+  TextInputProps,
+} from 'react-native'
 import { Picker } from '@react-native-picker/picker'
 import DatePicker from 'react-native-date-picker'
+import ActionSheet from 'react-native-actions-sheet'
 import { format } from 'date-fns'
 import {
   createRestyleComponent,
@@ -12,10 +18,13 @@ import {
   BorderProps,
   BackgroundColorProps,
   createVariant,
+  TextProps,
+  BoxProps,
 } from '@shopify/restyle'
 
 import { Text } from './Text'
 import { Box } from './Box'
+import { Pressable } from './Pressable'
 import { Theme } from '@utils/theme'
 
 const restyleFunctions = [
@@ -36,42 +45,46 @@ export const TextField = createRestyleComponent<Props, Theme>(
   TextInput,
 )
 
-type LabeledTextField = {
+type FormFieldProps = BoxProps<Theme> & {
   label: string
-  value: string
+  value: any
   onChange?: (string) => void
   onTap?: () => void
+  labelProps?: TextProps<Theme>
   disabled?: boolean
 }
 
-export const LabeledTextField: React.FC<LabeledTextField> = ({
+export const LabeledTextField: React.FC<FormFieldProps> = ({
   label,
   value,
   onChange,
   onTap,
   disabled,
+  labelProps = {},
   ...props
 }) => (
-  <Box width="100%" py={4}>
-    <Text fontWeight="bold" color="darkGrey" pb={2}>
-      {label}
-    </Text>
+  <Box width="100%" py={4} {...props}>
+    {!!label && (
+      <Text variant="heading3" pb={1} {...labelProps}>
+        {label}
+      </Text>
+    )}
+
     <TextField
       variant="login"
       autoCapitalize="none"
       autoCorrect={false}
       onChangeText={(text) => onChange?.(text)}
-      onTouchEnd={() => onTap?.()}
       value={value}
+      onTouchEnd={() => onTap?.()}
       editable={disabled !== true}
-      {...props}
     />
   </Box>
 )
 
-export const LabeledDateField = ({ label, value, onChange, ...props }) => (
-  <Box width="100%" py={4}>
-    <Text fontWeight="bold" color="darkGrey" pb={2}>
+export const LabeledDateField: React.FC<FormFieldProps> = ({ label, value, onChange, ...props }) => (
+  <Box width="100%" py={4} {...props}>
+    <Text variant="heading3" pb={1}>
       {label}
     </Text>
     <Box
@@ -89,58 +102,82 @@ export const LabeledDateField = ({ label, value, onChange, ...props }) => (
   </Box>
 )
 
-export const LabeledPickerField = ({
-  label,
-  value,
-  options = [],
-  onChange,
-}) => {
-  return (
-    <Box width="100%" py={4}>
-      <Text fontWeight="bold" color="darkGrey" pb={2}>
-        {label}
-      </Text>
-      <Box
-        borderColor="purple"
-        borderWidth={2}
-        borderRadius="m"
-        alignItems="center"
-        justifyContent="center"
-        pl={1}
-      >
-        <Picker
-          style={{ width: '100%' }}
-          selectedValue={value}
-          onValueChange={(itemValue, _) => onChange(itemValue)}
-        >
-          {options.map((option) => (
-            <Picker.Item {...option} />
-          ))}
-        </Picker>
-      </Box>
-    </Box>
-  )
+
+type PickerFieldProps = FormFieldProps & {
+  options: { value: string, label: string }[]
+  placeholder?: string
 }
 
-export const PickerField = ({ value, options = [], onChange }) => {
+export const LabeledPickerField: React.FC<PickerFieldProps>  = ({
+  label,
+  value,
+  placeholder,
+  options = [],
+  onChange,
+  ...props
+}) => {
+  const actionSheetRef = useRef<ActionSheet>(null)
+  const setModal = (open) => actionSheetRef.current?.setModalVisible(open)
+  const selectedLabel = options.find((option) => option.value == value)?.label
+  const maxHeight = Dimensions.get('screen').height * 0.7
+
   return (
-    <Box
-      borderColor="purple"
-      borderWidth={2}
-      borderRadius="m"
-      alignItems="center"
-      justifyContent="center"
-      pl={1}
-    >
-      <Picker
-        style={{ width: '100%' }}
-        selectedValue={value}
-        onValueChange={(itemValue, _) => onChange(itemValue)}
-      >
-        {options.map((option) => (
-          <Picker.Item {...option} />
-        ))}
-      </Picker>
-    </Box>
+    <>
+      <Box {...props}>
+        <Pressable onPress={() => setModal(true)} {...props}>
+          <Box width="100%">
+            {!!label && (
+              <Text variant="heading3" pb={2}>
+                {label}
+              </Text>
+            )}
+
+            <Box height={50} flex={1} flexDirection='row' alignItems='center' borderWidth={2} borderColor='purple' paddingLeft={4} borderRadius='m'>
+              <Text fontSize={14}> {selectedLabel ?? placeholder} </Text>
+            </Box>
+          </Box>
+        </Pressable>
+      </Box>
+
+      <ActionSheet ref={actionSheetRef} defaultOverlayOpacity={0.8} delayActionSheetDraw={false}>
+        <Box px={{ s: 4, m: 6 }}>
+          <Box
+            flexDirection="row"
+            justifyContent="space-between"
+            alignItems="flex-start"
+            py={6}
+          >
+            <Box maxWidth="75%">
+              <Text variant="heading2">{label}</Text>
+            </Box>
+            <Pressable mt={2} onPress={() => setModal(false)}>
+              <Text variant="buttonLabel" color="purple" fontSize={16}>
+                Done
+              </Text>
+            </Pressable>
+          </Box>
+
+          {/* <ScrollView> */}
+            <Box minHeight={300} pb={10} maxHeight={maxHeight}>
+              {options.map((option) => (
+                <Pressable onPress={() => onChange(option.value)}>
+                  <Box
+                    backgroundColor="offWhite"
+                    borderRadius="s"
+                    mb={3}
+                    px={2}
+                    py={3}
+                    borderColor={option.value == value ? 'purple' : 'offWhite'}
+                    borderWidth={3}
+                  >
+                    <Text variant="selectLabel">{option.label}</Text>
+                  </Box>
+                </Pressable>
+              ))}
+            </Box>
+          {/* </ScrollView> */}
+        </Box>
+      </ActionSheet>
+    </>
   )
 }

--- a/src/components/Interval.tsx
+++ b/src/components/Interval.tsx
@@ -20,7 +20,7 @@ export const Interval = () => {
         justifyContent="center"
         alignItems="center"
       >
-        <Text fontWeight="bold" fontSize={120}>
+        <Text fontFamily="Inter-SemiBold" fontSize={120}>
           +
         </Text>
       </Box>

--- a/src/components/NetworkError.tsx
+++ b/src/components/NetworkError.tsx
@@ -12,7 +12,7 @@ export const NetworkError = () => (
     borderWidth={4}
     borderRadius="m"
   >
-    <Text variant="heading3" fontWeight="600" color="darkGrey">
+    <Text variant="heading3" fontFamily="Inter-SemiBold" color="darkGrey">
       You do not have internet access, Please come back when you have a stable
       connection.
     </Text>

--- a/src/components/RatingScale.tsx
+++ b/src/components/RatingScale.tsx
@@ -114,7 +114,7 @@ export const RatingScale: React.FunctionComponent<RatingScaleProps> = ({
               onPress={() => (!locked ? setSelectionOption(value) : null)}
               disabled={disabled}
             >
-              <Text fontSize={20} fontWeight="bold" color="white">
+              <Text fontSize={20} fontFamily="Inter-SemiBold" color="white">
                 {value}
               </Text>
             </Pressable>
@@ -131,17 +131,17 @@ export const RatingScale: React.FunctionComponent<RatingScaleProps> = ({
           minHeight={minAnchorHeight}
         >
           <Box width="25%">
-            <Text textAlign="left" fontWeight="600">
+            <Text textAlign="left" fontFamily="Inter-SemiBold">
               {anchorLabelLeft}
             </Text>
           </Box>
           <Box width="33%">
-            <Text textAlign="center" fontWeight="600">
+            <Text textAlign="center" fontFamily="Inter-SemiBold">
               {anchorLabelCenter}
             </Text>
           </Box>
           <Box width="25%">
-            <Text textAlign="right" fontWeight="600">
+            <Text textAlign="right" fontFamily="Inter-SemiBold">
               {anchorLabelRight}
             </Text>
           </Box>

--- a/src/components/Stepper.tsx
+++ b/src/components/Stepper.tsx
@@ -28,7 +28,7 @@ export const Stepper = ({
       {/* Description Label */}
       <Box alignItems="center" marginTop={5}>
         <Text fontSize={16}>
-          <Text fontWeight="bold">{stageLabel}: </Text>
+          <Text fontFamily="Inter-SemiBold">{stageLabel}: </Text>
           Step {currentStep + 1} of {numberOfSteps}
         </Text>
       </Box>

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -38,7 +38,7 @@ export const Toast: React.FC<ToastProps> = ({ id, title, description }) => {
           shadowColor="black"
         >
           {/* Toast Heading */}
-          <Text color="darkGrey" fontSize={20} fontFamily="Inter-Bold">
+          <Text color="darkGrey" fontSize={20} fontFamily="Inter-SemiBold">
             {title}
           </Text>
 

--- a/src/containers/BasicInfoContainer.tsx
+++ b/src/containers/BasicInfoContainer.tsx
@@ -30,7 +30,6 @@ enum BasicInfoScreens {
 
 // When updating this list, you also need to update the portal.
 const DEFAULT_GENDERS = [
-  { label: '', value: null },
   { label: 'Male', value: 'male' },
   { label: 'Female', value: 'female' },
   { label: 'Non-binary', value: 'non_binary' },

--- a/src/containers/ExperimentContainer.tsx
+++ b/src/containers/ExperimentContainer.tsx
@@ -197,6 +197,7 @@ export const ExperimentContainer = () => {
   }
 
   // If the sound file is corrupt then terminate
+  console.log(usRef)
   if (usRef !== undefined && usRef.sound === null) {
     Alert.alert(JSON.stringify(usRef))
     terminateExperiment(true, 'CORRUPT_ASSETS')

--- a/src/containers/ExperimentContainer.tsx
+++ b/src/containers/ExperimentContainer.tsx
@@ -197,7 +197,6 @@ export const ExperimentContainer = () => {
   }
 
   // If the sound file is corrupt then terminate
-  console.log(usRef)
   if (usRef !== undefined && usRef.sound === null) {
     Alert.alert(JSON.stringify(usRef))
     terminateExperiment(true, 'CORRUPT_ASSETS')

--- a/src/screens/BreakEndScreen.tsx
+++ b/src/screens/BreakEndScreen.tsx
@@ -40,18 +40,18 @@ export const BreakEndScreen: React.FunctionComponent<BreakEndScreenProps> = ({
           {description}
         </Markdown>
 
-        <Text variant="caption2" fontWeight="600" pb={2}>
+        <Text variant="caption2" fontFamily="Inter-SemiBold" pb={2}>
           Time Left:
         </Text>
 
         {timerText && (
-          <Text fontWeight="800" textAlign="center" fontSize={45}>
+          <Text fontFamily="Inter-ExtraBold" textAlign="center" fontSize={45}>
             {timerText}
           </Text>
         )}
 
         {extendedTimerText && (
-          <Text fontWeight="800" textAlign="center" fontSize={20}>
+          <Text fontFamily="Inter-ExtraBold" textAlign="center" fontSize={20}>
             {extendedTimerText}
           </Text>
         )}
@@ -61,7 +61,7 @@ export const BreakEndScreen: React.FunctionComponent<BreakEndScreenProps> = ({
             <Text variant="caption2" fontSize={12} pt={10}>
               Break will end at:
             </Text>
-            <Text variant="caption2" fontWeight="600" pt={4}>
+            <Text variant="caption2" fontFamily="Inter-SemiBold" pt={4}>
               {eta}
             </Text>
           </>

--- a/src/screens/DeviceInfoScreen.tsx
+++ b/src/screens/DeviceInfoScreen.tsx
@@ -8,7 +8,6 @@ import {
   LabeledDateField,
   LabeledTextField,
   LabeledPickerField,
-  SafeAreaView,
 } from '@components'
 
 import { BasicInfoContainerState } from '@containers/BasicInfoContainer'
@@ -62,6 +61,7 @@ export const DeviceInfoScreen: React.FunctionComponent<DeviceInfoScreenProps> = 
         {shouldCollectDob && (
           <LabeledDateField
             label="Date of birth"
+            mb={2}
             value={
               dob ? new Date(dob) : dobValue ? new Date(dobValue) : new Date()
             }
@@ -74,6 +74,7 @@ export const DeviceInfoScreen: React.FunctionComponent<DeviceInfoScreenProps> = 
             label="Gender"
             value={genderValue}
             options={genders}
+            mb={2}
             onChange={setGenderValue}
             placeholder="Select your gender..."
           />
@@ -81,15 +82,17 @@ export const DeviceInfoScreen: React.FunctionComponent<DeviceInfoScreenProps> = 
         <LabeledTextField
           label="Operating System"
           value={operatingSystem}
+          mb={2}
           disabled
         />
-        <LabeledTextField label="OS Version" value={version} disabled />
+        <LabeledTextField label="OS Version" value={version} mb={2} disabled />
         <LabeledTextField
           label="Device Manufacturer"
           value={manufacturer}
+          mb={2}
           disabled
         />
-        <LabeledTextField label="Device Model" value={model} disabled />
+        <LabeledTextField label="Device Model" value={model} mb={2} disabled />
         {(shouldCollectGender ? gender != undefined : true) && (
           <Button
             variant="primary"

--- a/src/screens/ExternalLinkScreen.tsx
+++ b/src/screens/ExternalLinkScreen.tsx
@@ -80,7 +80,7 @@ export const ExternalLinkScreen: React.FunctionComponent<ExternalLinkScreenProps
           </TouchableOpacity>
         </Box>
         <Box width="50%" alignItems="center">
-          <Text color="white" fontSize={16} fontWeight="600">
+          <Text color="white" fontSize={16} fontFamily="Inter-SemiBold">
             {title}
           </Text>
         </Box>

--- a/src/screens/HeadphoneChoiceScreen.tsx
+++ b/src/screens/HeadphoneChoiceScreen.tsx
@@ -80,7 +80,7 @@ const HeadphoneButton = ({ active, image, label, onPress }) => {
         fontSize={16}
         pl={6}
         color={active ? 'white' : 'purple'}
-        fontWeight="bold"
+        fontFamily="Inter-SemiBold"
       >
         {label}
       </Text>

--- a/src/screens/HeadphonesDetectionScreen.tsx
+++ b/src/screens/HeadphonesDetectionScreen.tsx
@@ -54,7 +54,7 @@ export const HeadphonesDetectionScreen: React.FunctionComponent<HeadphonesDetect
         />
 
         <Text
-          fontWeight="700"
+          fontFamily="Inter-Bold"
           fontSize={22}
           color="darkGrey"
           textAlign="center"
@@ -74,7 +74,7 @@ export const HeadphonesDetectionScreen: React.FunctionComponent<HeadphonesDetect
         {connected == false && (
           <>
             <AntDesign name="closecircle" size={70} color={palette.red} />
-            <Text variant="caption2" fontWeight="500" mt={8}>
+            <Text variant="caption2" fontFamily="Inter" mt={8}>
               Plug in your headphones to continue.
             </Text>
           </>

--- a/src/screens/LoginScreen.tsx
+++ b/src/screens/LoginScreen.tsx
@@ -123,7 +123,7 @@ export const LoginScreen = () => {
             pt={10}
           >
             <Box width="100%" px={4}>
-              <Text fontWeight="bold" color="darkGrey" pb={2}>
+              <Text fontFamily="Inter-SemiBold" color="darkGrey" pb={2}>
                 Participant ID
               </Text>
               <TextField

--- a/src/screens/NotificationsScreen.tsx
+++ b/src/screens/NotificationsScreen.tsx
@@ -38,7 +38,7 @@ export const NotificationsScreen: React.FunctionComponent<IntervalExplainationSc
             paddingVertical={3}
             opacity={0.8}
           >
-            <Text fontWeight="600" fontSize={18} textAlign="center">
+            <Text fontFamily="Inter-SemiBold" fontSize={18} textAlign="center">
               Skip Notifications
             </Text>
           </Pressable>

--- a/src/screens/QuestionsScreen.tsx
+++ b/src/screens/QuestionsScreen.tsx
@@ -4,7 +4,7 @@ import {
   Text,
   RatingScale,
   CriterionToggle,
-  PickerField,
+  LabeledPickerField,
   Button,
 } from '@components'
 import {
@@ -20,15 +20,13 @@ type QuestionScreenProps = {
   onContinue: () => void
 }
 
-const headphoneOptions = [{ label: '', value: undefined }].concat(
-  [
-    "I hadn't heard any loud noises",
-    'After I heard one loud noise',
-    'After I heard a few loud noises',
-    'After I reached a break',
-    'During questionnaires',
-  ].map((q) => ({ label: q, value: q })),
-)
+const headphoneOptions = [
+  "I hadn't heard any loud noises",
+  'After I heard one loud noise',
+  'After I heard a few loud noises ya know?',
+  'After I reached a break',
+  'During questionnaires',
+].map((q) => ({ label: q, value: q }))
 
 export const QuestionsScreen: React.FC<QuestionScreenProps> = ({
   heading,
@@ -127,8 +125,10 @@ export const QuestionsScreen: React.FC<QuestionScreenProps> = ({
         )}
 
         {answers.didRemoveHeadphones && (
-          <QuestionBox heading="At what point did you remove your headphones?">
-            <PickerField
+          <QuestionBox>
+            <LabeledPickerField
+              label="At what point did you remove your headphones?"
+              placeholder="Pick an option..."
               options={headphoneOptions}
               value={answers.headphonesRemovalReason}
               onChange={(value) =>
@@ -209,9 +209,11 @@ export const QuestionsScreen: React.FC<QuestionScreenProps> = ({
 const QuestionBox = ({ heading, children }) => (
   <Box>
     <Box mt={4} px={6} pb={4}>
-      <Text variant="heading3" mb={6}>
-        {heading}
-      </Text>
+      {!!heading && (
+        <Text variant="heading3" mb={5}>
+          {heading}
+        </Text>
+      )}
 
       {children}
       <Box opacity={0.1} borderTopColor="darkGrey" borderTopWidth={2} mt={8} />

--- a/src/screens/QuestionsScreen.tsx
+++ b/src/screens/QuestionsScreen.tsx
@@ -23,7 +23,7 @@ type QuestionScreenProps = {
 const headphoneOptions = [
   "I hadn't heard any loud noises",
   'After I heard one loud noise',
-  'After I heard a few loud noises ya know?',
+  'After I heard a few loud noises',
   'After I reached a break',
   'During questionnaires',
 ].map((q) => ({ label: q, value: q }))

--- a/src/screens/ReimbursementScreen.tsx
+++ b/src/screens/ReimbursementScreen.tsx
@@ -22,7 +22,12 @@ export const ReimbursementScreen = ({ body, code, onExit }) => {
           borderWidth={4}
           borderColor="purple"
         >
-          <Text textAlign="center" fontSize={18} fontFamily="Inter-SemiBold" selectable>
+          <Text
+            textAlign="center"
+            fontSize={18}
+            fontFamily="Inter-SemiBold"
+            selectable
+          >
             {code}
           </Text>
         </Box>

--- a/src/screens/ReimbursementScreen.tsx
+++ b/src/screens/ReimbursementScreen.tsx
@@ -22,7 +22,7 @@ export const ReimbursementScreen = ({ body, code, onExit }) => {
           borderWidth={4}
           borderColor="purple"
         >
-          <Text textAlign="center" fontSize={18} fontWeight="bold" selectable>
+          <Text textAlign="center" fontSize={18} fontFamily="Inter-SemiBold" selectable>
             {code}
           </Text>
         </Box>

--- a/src/screens/RejectionScreen.tsx
+++ b/src/screens/RejectionScreen.tsx
@@ -68,7 +68,13 @@ export const RejectionScreen: React.FunctionComponent<RejectionScreenParams> = (
         </Text>
 
         <Box width="100%">
-          <Text fontFamily="Inter-Medium" color="darkGrey" fontSize={18} mt={2} p={0}>
+          <Text
+            fontFamily="Inter-Medium"
+            color="darkGrey"
+            fontSize={18}
+            mt={2}
+            p={0}
+          >
             {reasonCopy}
           </Text>
         </Box>

--- a/src/screens/RejectionScreen.tsx
+++ b/src/screens/RejectionScreen.tsx
@@ -68,7 +68,7 @@ export const RejectionScreen: React.FunctionComponent<RejectionScreenParams> = (
         </Text>
 
         <Box width="100%">
-          <Text fontWeight="500" color="darkGrey" fontSize={18} mt={2} p={0}>
+          <Text fontFamily="Inter-Medium" color="darkGrey" fontSize={18} mt={2} p={0}>
             {reasonCopy}
           </Text>
         </Box>

--- a/src/screens/VolumeCalibrationScreen.tsx
+++ b/src/screens/VolumeCalibrationScreen.tsx
@@ -213,7 +213,7 @@ export const VolumeCalibrationScreen: React.FunctionComponent<VolumeCalibrationS
         {/* Stimuli Countdown */}
         {stage == VolumeCalibrationStages.Countdown && countdown > 0 && (
           <Text
-            fontWeight="500"
+            fontFamily="Inter-Medium"
             width="100%"
             fontSize={80}
             mt={10}

--- a/src/screens/VolumeInstructionScreen.tsx
+++ b/src/screens/VolumeInstructionScreen.tsx
@@ -50,7 +50,7 @@ export const VolumeInstructionScreen: React.FunctionComponent<VolumeInstructionS
       </Text>
 
       {volume !== undefined && (
-        <Text fontWeight="bold" fontSize={60} color="purple">
+        <Text fontFamily="Inter-SemiBold" fontSize={60} color="purple">
           {(volume * 100).toFixed(0)}%
         </Text>
       )}

--- a/src/screens/__tests__/__snapshots__/CriteriaScreen.test.tsx.snap
+++ b/src/screens/__tests__/__snapshots__/CriteriaScreen.test.tsx.snap
@@ -217,7 +217,7 @@ exports[`Text Renders Correctly 1`] = `
                 Object {
                   "color": "#212529",
                   "display": "flex",
-                  "fontFamily": "Inter",
+                  "fontFamily": "Inter-SemiBold",
                   "fontSize": 20,
                   "fontWeight": "600",
                   "marginBottom": 8,
@@ -426,7 +426,7 @@ exports[`Text Renders Correctly 1`] = `
                 Object {
                   "color": "#212529",
                   "display": "flex",
-                  "fontFamily": "Inter",
+                  "fontFamily": "Inter-SemiBold",
                   "fontSize": 20,
                   "fontWeight": "600",
                   "marginBottom": 8,
@@ -635,7 +635,7 @@ exports[`Text Renders Correctly 1`] = `
                 Object {
                   "color": "#212529",
                   "display": "flex",
-                  "fontFamily": "Inter",
+                  "fontFamily": "Inter-SemiBold",
                   "fontSize": 20,
                   "fontWeight": "600",
                   "marginBottom": 8,

--- a/src/screens/__tests__/__snapshots__/RejectionScreen.test.tsx.snap
+++ b/src/screens/__tests__/__snapshots__/RejectionScreen.test.tsx.snap
@@ -57,8 +57,8 @@ exports[`Text Renders Correctly 1`] = `
           >
             <ForwardRef
               color="darkGrey"
+              fontFamily="Inter-Medium"
               fontSize={18}
-              fontWeight="500"
               mt={2}
               p={0}
             />
@@ -181,8 +181,8 @@ exports[`Text Renders Correctly 1`] = `
                 Object {
                   "color": "#212529",
                   "display": "flex",
+                  "fontFamily": "Inter-Medium",
                   "fontSize": 18,
-                  "fontWeight": "500",
                   "marginTop": 8,
                   "padding": 0,
                 },

--- a/src/utils/exampleExperiment.ts
+++ b/src/utils/exampleExperiment.ts
@@ -83,9 +83,9 @@ export const exampleExperimentData: Experiment = {
       id: '387484',
       moduleType: 'INSTRUCTIONS',
       definition: {
-        includeVolumeCalibration: true,
-        endScreenTitle: 'Hello, World',
-        endScreenBody: '',
+        includeVolumeCalibration: false,
+        endScreenTitle: 'Time to start the experiment.',
+        endScreenBody: "Press 'Next' to start the experiment.",
         screens: [
           {
             title: 'Check your surroundings',

--- a/src/utils/theme.tsx
+++ b/src/utils/theme.tsx
@@ -17,6 +17,7 @@ export const palette = {
   lightGrey: '#e4e9ed',
   black: '#0B0B0B',
   white: '#FFFF',
+  offWhite: '#F0F2F3',
 }
 
 export const theme = createTheme({
@@ -68,16 +69,15 @@ export const theme = createTheme({
       marginBottom: 3,
     },
     heading2: {
-      fontFamily: 'Inter',
+      fontFamily: 'Inter-SemiBold',
       fontSize: 20,
       fontWeight: '600',
       color: 'darkGrey',
       marginBottom: 2,
     },
     heading3: {
-      fontFamily: 'Inter',
+      fontFamily: 'Inter-Medium',
       fontSize: 16,
-      fontWeight: '500',
       color: 'darkGrey',
       marginBottom: 2,
     },
@@ -115,18 +115,17 @@ export const theme = createTheme({
       color: 'white',
     },
     instructionHeading: {
-      fontFamily: 'Inter',
-      fontWeight: '700',
+      fontFamily: 'Inter-Bold',
       fontSize: {
         s: 22,
         m: 25,
       },
       color: 'darkGrey',
       textAlign: 'center',
+
     },
     instructionDescription: {
-      fontFamily: 'Inter',
-      fontWeight: '500',
+      fontFamily: 'Inter-Medium',
       fontSize: {
         s: 16,
         m: 18,
@@ -135,11 +134,15 @@ export const theme = createTheme({
       textAlign: 'center',
     },
     instructionActionLabel: {
-      fontFamily: 'Inter',
-      fontWeight: '300',
+      fontFamily: 'Inter-Light',
       fontSize: 15,
       color: 'darkGrey',
       textAlign: 'center',
+    },
+    selectLabel: {
+      fontFamily: 'Inter-Medium',
+      fontSize: 15,
+      color: 'darkGrey',
     },
   },
   buttonVariants: {

--- a/src/utils/theme.tsx
+++ b/src/utils/theme.tsx
@@ -122,7 +122,6 @@ export const theme = createTheme({
       },
       color: 'darkGrey',
       textAlign: 'center',
-
     },
     instructionDescription: {
       fontFamily: 'Inter-Medium',


### PR DESCRIPTION
This PR add's a custom picker modal component to replace the native ones. The iOS and Android `Picker` components differ drastically so I've built a custom replacement where we can control issues such as text wrapping.

I have also fixed how we reference fonts in the JSX. Turns out Android wasn't picking up the old method properly.

Screenshot:
<img width="561" alt="CleanShot 2021-03-01 at 07 12 35@2x" src="https://user-images.githubusercontent.com/13197111/109464135-1606f000-7a5e-11eb-8cc5-aae0839ebf32.png">
